### PR TITLE
Fix how audience is checked, to manage the case where audience is an array

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -207,7 +207,7 @@ class LoginController extends Controller {
 		}
 
 		// Verify audience
-		if ($payload->aud !== $provider->getClientId()) {
+		if (!(($payload->aud === $provider->getClientId() || in_array($provider->getClientId(), $payload->aud, true)))) {
 			$this->logger->debug('This token is not for us');
 			// TODO: error properly
 			return new JSONResponse(['audience does not match']);


### PR DESCRIPTION
This fixes #13 

Now audience can be a string or an array, as specified in OpenID Connect specifications.