### PR TITLE
Disable autocomplete on sensible inputs

### DIFF
--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -56,7 +56,7 @@
 			<label for="oidc-client-id">{{ t('user_oidc', 'Client ID') }}</label>
 			<input id="oidc-client-id" v-model="newProvider.clientId" type="text">
 			<label for="oidc-client-secret">{{ t('user_oidc', 'Client secret') }}</label>
-			<input id="oidc-client-secret" v-model="newProvider.clientSecret" type="text">
+			<input id="oidc-client-secret" v-model="newProvider.clientSecret" type="text" autocomplete="off">
 			<label for="oidc-discovery-endpoint">{{ t('user_oidc', 'Discovery endpoint') }}</label>
 			<input id="oidc-discovery-endpoint" v-model="newProvider.discoveryEndpoint" type="text">
 


### PR DESCRIPTION
Avoid enabling autocomplete on the secret input to prevent leaking sensible credentials.