### PR TITLE
Add commandline setup for app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# NextCloud official OpenID connect provider app
+This is the officially supported NextCloud OpenId connect application to support login from providers
+using that open standnard.
+
+## General setup
+There is a good article on the internet to jumpstart the use of this app:
+
+
+## Commandline settings
+The app could also be configured by commandline.
+
+### Provider entries
+Providers are located by provider identifier.
+
+To show provider configuration, use:
+```
+sudo -u www-data php /ver/www/nextcloud/occ oidc:provider demoprovider
+```
+
+A provider is created if none with the given identifier exists and all parameters are given:
+```
+sudo -u www-data php /ver/www/nextcloud/occ oidc:provider demoprovider --clientid="WBXCa003871" \
+    --clientsecret="lbXy***********" --discoveryuri="https://accounts.central.de/openid-configuration"
+```
+
+To delete a provider, use:
+```
+sudo -u www-data php /ver/www/nextcloud/occ oidc:provider:remove demoprovider
+  Are you sure you want to delete OpenID Provider demoprovider
+  and may invalidate all assiciated user accounts.
+```
+To skip the confirmation, use `--force`.
+
+***Warning***: be careful with the deletion of a provider because in some setup, this invalidates access to all
+NextCloud accounts associated with this provider.
+
+
+### ID4me option
+ID4me is an application setting switch which is configurable as normal Nextcloud app setting:
+```
+sudo -u www-data php /ver/www/nextcloud/occ config:app:set --value=1 user_oidc id4me_enabled
+```
+

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 This is the officially supported NextCloud OpenId connect application to support login from providers
 using that open standnard.
 
-## General setup
-There is a good article on the internet to jumpstart the use of this app:
-
+## General usage
+See [Nextcloud and OpenID-Connect](https://www.schiessle.org/articles/2020/07/26/nextcloud-and-openid-connect/)
+for a proper jumpstart.
 
 ## Commandline settings
 The app could also be configured by commandline.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -24,4 +24,9 @@
 		<admin>OCA\UserOIDC\Settings\AdminSettings</admin>
 		<admin-section>OCA\UserOIDC\Settings\Section</admin-section>
 	</settings>
+
+	<commands>
+		<command>OCA\UserOIDC\Command\UpsertProvider</command>
+		<command>OCA\UserOIDC\Command\DeleteProvider</command>
+	</commands>
 </info>

--- a/lib/Command/DeleteProvider.php
+++ b/lib/Command/DeleteProvider.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\UserOIDC\Command;
 
-use OC\Core\Command\Base;
+use \Symfony\Component\Console\Command\Command;
 
 use OCA\UserOIDC\Db\ProviderMapper;
 
@@ -33,7 +33,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
-class DeleteProvider extends Base {
+class DeleteProvider extends Command {
 	private $providerMapper;
 
 	public function __construct(ProviderMapper $providerMapper) {

--- a/lib/Command/DeleteProvider.php
+++ b/lib/Command/DeleteProvider.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2018 Robin Appelman <robin@icewind.nl>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\UserOIDC\Command;
+
+use OC\Core\Command\Base;
+
+use OCA\UserOIDC\Db\ProviderMapper;
+use OCA\UserOIDC\Db\Provider;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+class DeleteProvider extends Base {
+	private $providerMapper;
+
+	public function __construct(ProviderMapper $providerMapper) {
+		parent::__construct();
+		$this->providerMapper = $providerMapper;
+	}
+
+	protected function configure() {
+		$this
+			->setName('user_oidc:provider:delete')
+			->setDescription('Delete OpenId connect provider connfig')
+			->addArgument('providerid', InputArgument::REQUIRED, 'Identification name of the provider config entry')
+			->addOption('force', 'f', InputOption::VALUE_NONE, 'Skip confirmation');
+		parent::configure();
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		try {
+			$providerid = $input->getArgument('providerid');
+			$helper = $this->getHelper('question');
+			$question = new ConfirmationQuestion('Are you sure you want to delete OpenID Provider ' . $providerid . '\nand may invalidate all assiciated user accounts.', false);
+			if ($input->getOption('force') || $helper->ask($input, $output, $question)) {
+				$this->providerMapper->deletePovider($providerid);
+			}
+		} catch(Exception $e) {
+			$output->writeln($e->getMessage());
+			return -1;
+		}
+	}
+}

--- a/lib/Command/DeleteProvider.php
+++ b/lib/Command/DeleteProvider.php
@@ -53,9 +53,9 @@ class DeleteProvider extends Base {
 		try {
 			$providerid = $input->getArgument('providerid');
 			$helper = $this->getHelper('question');
-			$question = new ConfirmationQuestion('Are you sure you want to delete OpenID Provider ' . $providerid . '\nand may invalidate all assiciated user accounts.', false);
+			$question = new ConfirmationQuestion('Are you sure you want to delete OpenID Provider "' . $providerid . '" and may invalidate all assiciated user accounts [y/n] ', false);
 			if ($input->getOption('force') || $helper->ask($input, $output, $question)) {
-				$this->providerMapper->deletePovider($providerid);
+				$this->providerMapper->deleteProvider($providerid);
 			}
 		} catch(Exception $e) {
 			$output->writeln($e->getMessage());

--- a/lib/Command/DeleteProvider.php
+++ b/lib/Command/DeleteProvider.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2018 Robin Appelman <robin@icewind.nl>
  *
@@ -24,7 +26,6 @@ namespace OCA\UserOIDC\Command;
 use OC\Core\Command\Base;
 
 use OCA\UserOIDC\Db\ProviderMapper;
-use OCA\UserOIDC\Db\Provider;
 
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -57,7 +58,7 @@ class DeleteProvider extends Base {
 			if ($input->getOption('force') || $helper->ask($input, $output, $question)) {
 				$this->providerMapper->deleteProvider($providerid);
 			}
-		} catch(Exception $e) {
+		} catch (Exception $e) {
 			$output->writeln($e->getMessage());
 			return -1;
 		}

--- a/lib/Command/UpsertProvider.php
+++ b/lib/Command/UpsertProvider.php
@@ -27,6 +27,7 @@ use OCA\UserOIDC\Db\ProviderMapper;
 use OCA\UserOIDC\Db\Provider;
 
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -54,7 +55,7 @@ class UpsertProvider extends Base {
 		$providerid   = $input->getArgument('providerid');
 		$clientid     = $input->getOption('clientid');
 		$clientsecret = $input->getOption('clientsecret');
-		$discoveriuri = $input->getOption('discoveryuri');
+		$discoveryuri = $input->getOption('discoveryuri');
 
 		if (false === $clientid) {
 			// in this case, the option was not passed when running the command
@@ -66,38 +67,33 @@ class UpsertProvider extends Base {
 			// handle it the same as a lacking value
 			$clientsecret = null;
 		}
-		if (false === $clientid) {
+		if (false === $discoveryuri) {
 			// in this case, the option was not passed when running the command
 			// handle it the same as a lacking value
 			$discoveryuri = null;
 		}
 
 		// show (unprotected) data in case no field is given
-		if ( (null === $clientid) && 
-		     (null === $clientsecret) && 
-			 (null === $dicoveryuri) ) {
-			try {
-				$provider = $this->providerMapper->findByIdentifier($providerid);
+		try {
+			if ( (null === $clientid) && 
+			     (null === $clientsecret) && 
+				 (null === $dicoveryuri) ) {
+				$provider = $this->providerMapper->findProviderByIdentifier($providerid);
 				if (null === $provider) {
 					return -4;
 				}
-				$output->write("{'" . $providerid . "': { 'identifier': '" . $provider . "', ");
-				$output->write(."'clientid': '" . $provider->getClientId() ."', ");   
-				$output->write(."'clientsecret': '***', "   
-				$output->write(."'discoveryuri': '" . $provider->getDiscoveryEndpoint() ."', ");   
-				$output->writeln(" }}");
-			} catch(Exception $e) {
-				$output->writeln($e->getMessage());
-				return -1;
-			}	
-		} else {
-			try {
-				$this->providerMapper->createOrUpdateProvider($providerid, $clientid, $clientsecret, $discoveriuri);
-			} catch(Exception $e) {
-				$output->writeln($e->getMessage());
-				return -1;
-			}	
-		}
+				$output->write("{ 'identifier': '" . $provider->getIdentifier() . "', ");
+				$output->write("'clientid': '" . $provider->getClientId() . "', ");   
+				$output->write("'clientsecret': '***', ");   
+				$output->write("'discoveryuri': '" . $provider->getDiscoveryEndpoint() . "', ");   
+				$output->writeln("}");
+			} else {
+				$this->providerMapper->createOrUpdateProvider($providerid, $clientid, $clientsecret, $discoveryuri);
+			}
+		} catch(Exception $e) {
+			$output->writeln($e->getMessage());
+			return -1;
+		}	
 
 		return 0;
 	}

--- a/lib/Command/UpsertProvider.php
+++ b/lib/Command/UpsertProvider.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace OCA\UserOIDC\Command;
 
-use OC\Core\Command\Base;
+use \Symfony\Component\Console\Command\Command;
 
 use OCA\UserOIDC\Db\ProviderMapper;
 
@@ -31,7 +31,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class UpsertProvider extends Base {
+class UpsertProvider extends Command {
 	private $providerMapper;
 
 	public function __construct(ProviderMapper $providerMapper) {

--- a/lib/Command/UpsertProvider.php
+++ b/lib/Command/UpsertProvider.php
@@ -1,4 +1,6 @@
-<?php declare(strict_types=1);
+<?php
+
+declare(strict_types=1);
 /**
  * @copyright Copyright (c) 2021 Bernd Rederlechner tsdicloud@github.com>
  *
@@ -24,9 +26,7 @@ namespace OCA\UserOIDC\Command;
 use OC\Core\Command\Base;
 
 use OCA\UserOIDC\Db\ProviderMapper;
-use OCA\UserOIDC\Db\Provider;
 
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -51,8 +51,8 @@ class UpsertProvider extends Base {
 	}
 
 	protected function execute(InputInterface $input, OutputInterface $output) {
-		$providerid   = $input->getArgument('providerid');
-		$clientid     = $input->getOption('clientid');
+		$providerid = $input->getArgument('providerid');
+		$clientid = $input->getOption('clientid');
 		$clientsecret = $input->getOption('clientsecret');
 		$discoveryuri = $input->getOption('discoveryuri');
 
@@ -69,22 +69,22 @@ class UpsertProvider extends Base {
 		}
 		// show (unprotected) data in case no field is given
 		try {
-			if ( (null === $clientid) && 
-			     (null === $clientsecret) && 
-				 (null === $discoveryuri) ) {
+			if ((null === $clientid) &&
+				 (null === $clientsecret) &&
+				 (null === $discoveryuri)) {
 				$provider = $this->providerMapper->findProviderByIdentifier($providerid);
 				$output->write("{ 'identifier': '" . $provider->getIdentifier() . "', ");
-				$output->write("'clientid': '" . $provider->getClientId() . "', ");   
-				$output->write("'clientsecret': '***', ");   
-				$output->write("'discoveryuri': '" . $provider->getDiscoveryEndpoint() . "', ");   
+				$output->write("'clientid': '" . $provider->getClientId() . "', ");
+				$output->write("'clientsecret': '***', ");
+				$output->write("'discoveryuri': '" . $provider->getDiscoveryEndpoint() . "', ");
 				$output->writeln("}");
 			} else {
 				$this->providerMapper->createOrUpdateProvider($providerid, $clientid, $clientsecret, $discoveryuri);
 			}
-		} catch(Exception $e) {
+		} catch (Exception $e) {
 			$output->writeln($e->getMessage());
 			return -1;
-		}	
+		}
 
 		return 0;
 	}

--- a/lib/Command/UpsertProvider.php
+++ b/lib/Command/UpsertProvider.php
@@ -46,8 +46,7 @@ class UpsertProvider extends Base {
 			->addArgument('providerid', InputOption::VALUE_REQUIRED, 'Administrative identifier name of the provider in the setup')
 			->addOption('clientid', 'c', InputOption::VALUE_REQUIRED, 'OpenID client identifier')
 			->addOption('clientsecret', 's', InputOption::VALUE_REQUIRED, 'OpenID client secret')
-			->addOption('discoveryuri', 'e', InputOption::VALUE_REQUIRED, 'OpenID discovery endpoint uri');
-
+			->addOption('discoveryuri', 'd', InputOption::VALUE_REQUIRED, 'OpenID discovery endpoint uri');
 		parent::configure();
 	}
 
@@ -63,25 +62,17 @@ class UpsertProvider extends Base {
 			$clientid = null;
 		}
 		if (false === $clientsecret) {
-			// in this case, the option was not passed when running the command
-			// handle it the same as a lacking value
 			$clientsecret = null;
 		}
 		if (false === $discoveryuri) {
-			// in this case, the option was not passed when running the command
-			// handle it the same as a lacking value
 			$discoveryuri = null;
 		}
-
 		// show (unprotected) data in case no field is given
 		try {
 			if ( (null === $clientid) && 
 			     (null === $clientsecret) && 
-				 (null === $dicoveryuri) ) {
+				 (null === $discoveryuri) ) {
 				$provider = $this->providerMapper->findProviderByIdentifier($providerid);
-				if (null === $provider) {
-					return -4;
-				}
 				$output->write("{ 'identifier': '" . $provider->getIdentifier() . "', ");
 				$output->write("'clientid': '" . $provider->getClientId() . "', ");   
 				$output->write("'clientsecret': '***', ");   

--- a/lib/Command/UpsertProvider.php
+++ b/lib/Command/UpsertProvider.php
@@ -1,0 +1,104 @@
+<?php declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2021 Bernd Rederlechner tsdicloud@github.com>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\UserOIDC\Command;
+
+use OC\Core\Command\Base;
+
+use OCA\UserOIDC\Db\ProviderMapper;
+use OCA\UserOIDC\Db\Provider;
+
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class UpsertProvider extends Base {
+	private $providerMapper;
+
+	public function __construct(ProviderMapper $providerMapper) {
+		parent::__construct();
+		$this->providerMapper = $providerMapper;
+	}
+
+	protected function configure() {
+		$this
+			->setName('user_oidc:provider')
+			->setDescription('Create, show or update a OpenId connect provider connfig given the identifier of a provider')
+			->addArgument('providerid', InputOption::VALUE_REQUIRED, 'Administrative identifier name of the provider in the setup')
+			->addOption('clientid', 'c', InputOption::VALUE_REQUIRED, 'OpenID client identifier')
+			->addOption('clientsecret', 's', InputOption::VALUE_REQUIRED, 'OpenID client secret')
+			->addOption('discoveryuri', 'e', InputOption::VALUE_REQUIRED, 'OpenID discovery endpoint uri');
+
+		parent::configure();
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$providerid   = $input->getArgument('providerid');
+		$clientid     = $input->getOption('clientid');
+		$clientsecret = $input->getOption('clientsecret');
+		$discoveriuri = $input->getOption('discoveryuri');
+
+		if (false === $clientid) {
+			// in this case, the option was not passed when running the command
+			// handle it the same as a lacking value
+			$clientid = null;
+		}
+		if (false === $clientsecret) {
+			// in this case, the option was not passed when running the command
+			// handle it the same as a lacking value
+			$clientsecret = null;
+		}
+		if (false === $clientid) {
+			// in this case, the option was not passed when running the command
+			// handle it the same as a lacking value
+			$discoveryuri = null;
+		}
+
+		// show (unprotected) data in case no field is given
+		if ( (null === $clientid) && 
+		     (null === $clientsecret) && 
+			 (null === $dicoveryuri) ) {
+			try {
+				$provider = $this->providerMapper->findByIdentifier($providerid);
+				if (null === $provider) {
+					return -4;
+				}
+				$output->write("{'" . $providerid . "': { 'identifier': '" . $provider . "', ");
+				$output->write(."'clientid': '" . $provider->getClientId() ."', ");   
+				$output->write(."'clientsecret': '***', "   
+				$output->write(."'discoveryuri': '" . $provider->getDiscoveryEndpoint() ."', ");   
+				$output->writeln(" }}");
+			} catch(Exception $e) {
+				$output->writeln($e->getMessage());
+				return -1;
+			}	
+		} else {
+			try {
+				$this->providerMapper->createOrUpdateProvider($providerid, $clientid, $clientsecret, $discoveriuri);
+			} catch(Exception $e) {
+				$output->writeln($e->getMessage());
+				return -1;
+			}	
+		}
+
+		return 0;
+	}
+}

--- a/lib/Db/ProviderMapper.php
+++ b/lib/Db/ProviderMapper.php
@@ -114,6 +114,7 @@ class ProviderMapper extends QBMapper {
 			$provider->setClientId($clientid);
 			$provider->setClientSecret($clientsecret);
 			$provider->setDiscoveryEndpoint($discoveryuri);
+			return $this->insert($provider);
 		} else {
 			if ( $clientid !== null ) {
 				$provider->setClientId($clientid);
@@ -121,12 +122,11 @@ class ProviderMapper extends QBMapper {
 			if ( $clientsecret !== null ) {
 				$provider->setClientSecret($clientsecret);
 			}
-			if ( $disvoveryuri !== null ) {
+			if ( $discoveryuri !== null ) {
 				$provider->setDiscoveryEndpoint($discoveryuri);
 			}
+			return $this->update($provider);
 		}
-
-		return $this->insertOrUpdate($provider);
 	}
 
 	/**

--- a/lib/Db/ProviderMapper.php
+++ b/lib/Db/ProviderMapper.php
@@ -128,16 +128,14 @@ class ProviderMapper extends QBMapper {
 	}
 
 	/**
-	 * Create or update provider settinngs
+	 * Delete provider settinngs
 	 *
 	 * @param string identifier
 	 */
-	public function deleteProvider(string $identifier) {
+	public function deleteProvider(string $identifier): void {
 		$provider = $this->findProviderByIdentifier($identifier);
 		if (null !== $provider) {
-			return $this->delete($provider);
-		} else {
-			return null;
+			$this->delete($provider);
 		}
 	}
 }

--- a/lib/Db/ProviderMapper.php
+++ b/lib/Db/ProviderMapper.php
@@ -100,25 +100,26 @@ class ProviderMapper extends QBMapper {
 	public function createOrUpdateProvider(string $identifier, string $clientid = null,
 	   								string $clientsecret = null, string $discoveryuri = null) {
 		try {
-			$provider = findByIdentifier($identifier);
+			$provider = $this->findProviderByIdentifier($identifier);
 		} catch (DoesNotExistException $eNotExist) {
 			$provider = null;
 		}
 
 		if ($provider === null) {
 			$provider = new Provider();
-			if ( $clientid === null ) || ( $clientsecret === null ) || ( discoveryuri === null ) {
+			if (( $clientid === null ) || ( $clientsecret === null ) || ( $discoveryuri === null )) {
 				throw new DoesNotExistException("Provider must be created. All provider parameters required.");
 			}
-			$provider->setClientId($clientId);
-			$provider->setClientSecret($clientSecret);
+			$provider->setIdentifier($identifier);
+			$provider->setClientId($clientid);
+			$provider->setClientSecret($clientsecret);
 			$provider->setDiscoveryEndpoint($discoveryuri);
 		} else {
 			if ( $clientid !== null ) {
-				$provider->setClientId($clientId);
+				$provider->setClientId($clientid);
 			}
 			if ( $clientsecret !== null ) {
-				$provider->setClientSecret($clientSecret);
+				$provider->setClientSecret($clientsecret);
 			}
 			if ( $disvoveryuri !== null ) {
 				$provider->setDiscoveryEndpoint($discoveryuri);
@@ -134,7 +135,7 @@ class ProviderMapper extends QBMapper {
 	 * @param string identifier
 	 */
 	public function deleteProvider(string $identifier) {
-		$provider = $this->findByIdentifier($identifier);
+		$provider = $this->findProviderByIdentifier($identifier);
 		if (null !== $provider) {
 			return $this->delete($provider);
 		} else {

--- a/lib/Db/ProviderMapper.php
+++ b/lib/Db/ProviderMapper.php
@@ -29,8 +29,6 @@ use OCP\AppFramework\Db\QBMapper;
 use OCP\IDBConnection;
 
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\AppFramework\Db\MultipleObjectsReturnedException;
-
 
 class ProviderMapper extends QBMapper {
 	public function __construct(IDBConnection $db) {
@@ -89,7 +87,7 @@ class ProviderMapper extends QBMapper {
 
 	/**
 	 * Create or update provider settinngs
-	 * 
+	 *
 	 * @param string identifier
 	 * @param string|null $clientid
 	 * @param string|null $clientsecret
@@ -98,7 +96,7 @@ class ProviderMapper extends QBMapper {
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
 	 */
 	public function createOrUpdateProvider(string $identifier, string $clientid = null,
-	   								string $clientsecret = null, string $discoveryuri = null) {
+									string $clientsecret = null, string $discoveryuri = null) {
 		try {
 			$provider = $this->findProviderByIdentifier($identifier);
 		} catch (DoesNotExistException $eNotExist) {
@@ -107,7 +105,7 @@ class ProviderMapper extends QBMapper {
 
 		if ($provider === null) {
 			$provider = new Provider();
-			if (( $clientid === null ) || ( $clientsecret === null ) || ( $discoveryuri === null )) {
+			if (($clientid === null) || ($clientsecret === null) || ($discoveryuri === null)) {
 				throw new DoesNotExistException("Provider must be created. All provider parameters required.");
 			}
 			$provider->setIdentifier($identifier);
@@ -116,13 +114,13 @@ class ProviderMapper extends QBMapper {
 			$provider->setDiscoveryEndpoint($discoveryuri);
 			return $this->insert($provider);
 		} else {
-			if ( $clientid !== null ) {
+			if ($clientid !== null) {
 				$provider->setClientId($clientid);
 			}
-			if ( $clientsecret !== null ) {
+			if ($clientsecret !== null) {
 				$provider->setClientSecret($clientsecret);
 			}
-			if ( $discoveryuri !== null ) {
+			if ($discoveryuri !== null) {
 				$provider->setDiscoveryEndpoint($discoveryuri);
 			}
 			return $this->update($provider);
@@ -131,7 +129,7 @@ class ProviderMapper extends QBMapper {
 
 	/**
 	 * Create or update provider settinngs
-	 * 
+	 *
 	 * @param string identifier
 	 */
 	public function deleteProvider(string $identifier) {
@@ -142,5 +140,4 @@ class ProviderMapper extends QBMapper {
 			return null;
 		}
 	}
-
 }


### PR DESCRIPTION
### Status
The OpenId app could only be configured by user interface.

### Proposal:
At least the provider configuration should be possible via commandline
to support automated operations.

>To show provider configuration, use:
>```
>sudo -u www-data php /ver/www/nextcloud/occ oidc:provider demoprovider
>```
>
>A provider is created if none with the given identifier exists and all parameters are given:
>```
>sudo -u www-data php /ver/www/nextcloud/occ oidc:provider demoprovider --clientid="WBXCa003871" \
>    --clientsecret="lbXy***********" --discoveryuri="https://accounts.central.de/openid-configuration"
>```
>
>To delete a provider, use:
>```
>sudo -u www-data php /ver/www/nextcloud/occ oidc:provider:remove demoprovider
> Are you sure you want to delete OpenID Provider demoprovider
> and may invalidate all assiciated user accounts.
>```
> To skip the confirmation, use `--force`.


The description of the commands as well as a link to a tutorial about the app usage is also included in the pull request.

### Limitations:
The new field mapping functionality is not backed up by commands (yet).