### PR TITLE
Properly handle redirect after login

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -30,6 +30,7 @@ use OCA\UserOIDC\Service\ID4MeService;
 use OCA\UserOIDC\User\Backend;
 use OCP\AppFramework\App;
 use OCP\IL10N;
+use OCP\IRequest;
 use OCP\IURLGenerator;
 use OCP\IUserManager;
 use OCP\IUserSession;
@@ -62,11 +63,14 @@ class Application extends App {
 
 			/** @var IL10N $l10n */
 			$l10n = $this->getContainer()->query(IL10N::class);
+			$request = $this->getContainer()->query(IRequest::class);
+
+			$redirectUrl = $request->getParam('redirect_url');
 
 			foreach ($providers as $provider) {
 				\OC_App::registerLogIn([
 					'name' => $l10n->t('Login with %1s', [$provider->getIdentifier()]),
-					'href' => $urlGenerator->linkToRoute(self::APP_ID . '.login.login', ['providerId' => $provider->getId()]),
+					'href' => $urlGenerator->linkToRoute(self::APP_ID . '.login.login', ['providerId' => $provider->getId(), 'redirectUrl' => $redirectUrl]),
 				]);
 			}
 

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -50,6 +50,7 @@ class LoginController extends Controller {
 	private const STATE = 'oidc.state';
 	private const NONCE = 'oidc.nonce';
 	private const PROVIDERID = 'oidc.providerid';
+	private const REDIRECT_AFTER_LOGIN = 'oidc.redirect';
 
 	/** @var ISecureRandom */
 	private $random;
@@ -126,7 +127,7 @@ class LoginController extends Controller {
 	 * @NoCSRFRequired
 	 * @UseSession
 	 */
-	public function login(int $providerId) {
+	public function login(int $providerId, string $redirectUrl = null) {
 		$this->logger->debug('Initiating login for provider with id: ' . $providerId);
 
 		//TODO: handle exceptions
@@ -134,6 +135,7 @@ class LoginController extends Controller {
 
 		$state = $this->random->generate(32, ISecureRandom::CHAR_DIGITS . ISecureRandom::CHAR_UPPER);
 		$this->session->set(self::STATE, $state);
+		$this->session->set(self::REDIRECT_AFTER_LOGIN, $redirectUrl);
 
 		$nonce = $this->random->generate(32, ISecureRandom::CHAR_DIGITS . ISecureRandom::CHAR_UPPER);
 		$this->session->set(self::NONCE, $nonce);
@@ -281,7 +283,10 @@ class LoginController extends Controller {
 
 		$this->logger->debug('Redirecting user');
 
-		// TODO: user proper redirect url
+		$redirectUrl = $this->session->get(self::REDIRECT_AFTER_LOGIN);
+		if ($redirectUrl) {
+			return new RedirectResponse($redirectUrl);
+		}
 
 		return new RedirectResponse(\OC_Util::getDefaultPageUrl());
 	}


### PR DESCRIPTION
Make sure that redirect urls are handled properly especially when using the login flow v2 in the client which would otherwise just show the regular user interface after granting access.