### PR TITLE
Allow to disable other login methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ ID4me is an application setting switch which is configurable as normal Nextcloud
 sudo -u www-data php /var/www/nextcloud/occ config:app:set --value=1 user_oidc id4me_enabled
 ```
 
+### Disable other login methods
+If there is only one OIDC provider configured, it can be made the default login
+method and the user would get redirected to the provider immediately for the
+login. Admins can still use the regular login through adding the `?direct=1`
+parameter to the login URL.
+
+```bash
+sudo -u www-data php var/www/nextcloud/occ config:app:set --value=0 user_oidc allow_multiple_user_backends
+```
+
 ## Building the app
 
 Requirements for building:

--- a/lib/Service/SettingsService.php
+++ b/lib/Service/SettingsService.php
@@ -1,0 +1,48 @@
+<?php
+/*
+ * @copyright Copyright (c) 2021 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+
+namespace OCA\UserOIDC\Service;
+
+use OCA\UserOIDC\AppInfo\Application;
+use OCP\IConfig;
+
+class SettingsService {
+
+	/** @var IConfig */
+	private $config;
+
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	public function getAllowMultipleUserBackEnds(): bool {
+		return $this->config->getAppValue(Application::APP_ID, 'allow_multiple_user_backends', '1') === '1';
+	}
+
+	public function setAllowMultipleUserBackEnds(bool $value): void {
+		$this->config->setAppValue(Application::APP_ID, 'allow_multiple_user_backends', $value ? '1' : '0');
+	}
+}


### PR DESCRIPTION
This adds the option to directly redirect to the oidc provider through a setting if only one provider is configured, similar to how the SAML integation handles it.

This currently does not allow to only use user_oidc with multiple providers as the app currently users the alternative logins API and we don't have a way to disable other providers from within the app. This would be something we could however enhance in server to allow admins to disable the regular login form there through a config.php option for example, but this covers the current use case with just one provider.

Based on #303 