### PR TITLE
Fix provider edition

### DIFF
--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -78,8 +78,8 @@ class SettingsController extends Controller {
 	public function updateProvider(int $providerId, string $identifier, string $clientId, string $discoveryEndpoint, string $clientSecret = null, array $settings = []): JSONResponse {
 		$provider = $this->providerMapper->getProvider($providerId);
 
-		if ($this->providerService->getProviderByIdentifier($identifier) !== null) {
-			return new JSONResponse(['message' => 'Provider with the given identifier already exists'], Http::STATUS_CONFLICT);
+		if ($this->providerService->getProviderByIdentifier($identifier) === null) {
+			return new JSONResponse(['message' => 'Provider with the given identifier does not exist'], Http::STATUS_NOT_FOUND);
 		}
 
 		$provider->setIdentifier($identifier);

--- a/lib/Service/ProviderService.php
+++ b/lib/Service/ProviderService.php
@@ -133,7 +133,7 @@ class ProviderService {
 
 	private function convertToJSON(string $key, $value) {
 		if ($key === self::SETTING_UNIQUE_UID) {
-			$value = $value === '1';
+			return $value === '1';
 		}
 		return (string)$value;
 	}


### PR DESCRIPTION
* `Http::STATUS_CONFLICT` was always returned on provider edition, condition is fixed and `Http::STATUS_NOT_FOUND` is not returned when the provider does not exist
* The boolean value (provided via initial state) of the "Use unique user id" field was casted to string which led to an invalid value in the UI and a frozen checkbox.