### PR TITLE
Claim handling and complex mapping rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,17 @@ The app uses [krankerl](https://github.com/ChristophWurst/krankerl) to build the
 The release will be put into `build/artifacts/` when running the `krankerl package`.
 
 The app can also be built without krankerl by manually running:
-
 ```
 composer install --no-dev -o
-npm install
+npm install npm
 npm run build
 ```
+
+On Ubuntu 20.04, a possible way to get build working is with matching npm and node versions is:
+```
+sudo apt-get remove nodejs
+sudo curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash - 
+sudo apt-get install nodejs
+```
+
+

--- a/README.md
+++ b/README.md
@@ -78,15 +78,16 @@ The release will be put into `build/artifacts/` when running the `krankerl packa
 The app can also be built without krankerl by manually running:
 ```
 composer install --no-dev -o
-npm install npm
+npm ci
 npm run build
 ```
 
 On Ubuntu 20.04, a possible way to get build working is with matching npm and node versions is:
 ```
 sudo apt-get remove nodejs
-sudo curl -sL https://deb.nodesource.com/setup_16.x | sudo -E bash - 
+sudo curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash - 
 sudo apt-get install nodejs
+sudo npm install -g npm@7
 ```
 
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -3,8 +3,8 @@
   xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
 	<id>user_oidc</id>
 	<name>OpenID Connect user backend</name>
-	<summary>Use an OpenID Connect backed to login to your Nextcloud</summary>
-	<description>Allows felxible configuration of an OIDC server as Nextcloud login user backend.</description>
+	<summary>Use an OpenID Connect backend to login to your Nextcloud</summary>
+	<description>Allows flexible configuration of an OIDC server as Nextcloud login user backend.</description>
 	<version>1.1.0-dev1</version>
 	<licence>agpl</licence>
 	<author>Roeland Jago Douma</author>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -3,11 +3,13 @@
   xsi:noNamespaceSchemaLocation="https://apps.nextcloud.com/schema/apps/info.xsd">
 	<id>user_oidc</id>
 	<name>OpenID Connect user backend</name>
-	<summary>Use an openID connect backed to login to your Nextcloud</summary>
-	<description>Allow configuring an OIDC server as Nextcloud user backend.</description>
+	<summary>Use an OpenID Connect backed to login to your Nextcloud</summary>
+	<description>Allows felxible configuration of an OIDC server as Nextcloud login user backend.</description>
 	<version>1.0.0</version>
 	<licence>agpl</licence>
 	<author>Roeland Jago Douma</author>
+	<author>Julius Härtl</author>
+	<author>Bernd Rederlechner</author>
 	<namespace>UserOIDC</namespace>
 	<types>
 		<authentication/>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
 	<name>OpenID Connect user backend</name>
 	<summary>Use an OpenID Connect backed to login to your Nextcloud</summary>
 	<description>Allows felxible configuration of an OIDC server as Nextcloud login user backend.</description>
-	<version>1.0.0</version>
+	<version>1.1.0-dev1</version>
 	<licence>agpl</licence>
 	<author>Roeland Jago Douma</author>
 	<author>Julius Härtl</author>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -102,7 +102,6 @@ class Application extends App {
 					'href' => $urlGenerator->linkToRoute(self::APP_ID . '.id4me.login'),
 				]);
 			}
-			return;
 		}
 	}
 }

--- a/lib/Command/UpsertProvider.php
+++ b/lib/Command/UpsertProvider.php
@@ -56,8 +56,7 @@ class UpsertProvider extends Command {
 			->addOption('clientsecret', 's', InputOption::VALUE_REQUIRED, 'OpenID client secret')
 			->addOption('discoveryuri', 'd', InputOption::VALUE_REQUIRED, 'OpenID discovery endpoint uri')
 
-			->addOption('scope', 'o', InputOption::VALUE_OPTIONAL, 'OpenID requested value scopes, defaults to "openid email profile"')
-			->addOption('customquery', 'q', InputOption::VALUE_OPTION, 'Custom query string to append to discovery request')
+			->addOption('scope', 'o', InputOption::VALUE_OPTIONAL, 'OpenID requested value scopes, if not set defaults to "openid email profile"')
 			->addOption('unique-uid', null, InputOption::VALUE_OPTIONAL, 'Flag if unique user ids shall be used or not. 1 to enable (default), 0 to disable.')
 			->addOption('mapping-display-name', null, InputOption::VALUE_OPTIONAL, 'Attribute mapping of the display name')
 			->addOption('mapping-email', null, InputOption::VALUE_OPTIONAL, 'Attribute mapping of the email address')
@@ -85,7 +84,6 @@ class UpsertProvider extends Command {
 		$clientid = $input->getOption('clientid');
 		$clientsecret = $input->getOption('clientsecret');
 		$discoveryuri = $input->getOption('discoveryuri');
-		$customQuery = $input->getOption('customquery');
 		$scope = $input->getOption('scope') ?? 'openid email profile';
 
 		try {
@@ -93,7 +91,7 @@ class UpsertProvider extends Command {
 			$updateOptions = array_filter($input->getOptions(), static function ($value, $option) {
 				return in_array($option, [
 					'identifier', 'clientid', 'clientsecret', 'discoveryuri',
-					'scope', 'customquery', 'unique-uid',
+					'scope', 'unique-uid',
 					'mapping-uid', 'mapping-display-name', 'mapping-email', 'mapping-quota',
 				]) && $value !== null;
 			}, ARRAY_FILTER_USE_BOTH);

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -258,7 +258,7 @@ class LoginController extends Controller {
 		if (!isset($payload->{$uidAttribute})) {
 			return new JSONResponse($payload);
 		}
-		$event = new AttributeMappedEvent(ProviderService::SETTING_MAPPING_UID, $payload->{$uidAttribute});
+		$event = new AttributeMappedEvent(ProviderService::SETTING_MAPPING_UID, $payload, $payload->{$uidAttribute});
 		$this->eventDispatcher->dispatchTyped($event);
 		$backendUser = $this->userMapper->getOrCreate($providerId, $event->getValue());
 
@@ -273,7 +273,7 @@ class LoginController extends Controller {
 		$displaynameAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_DISPLAYNAME, 'name');
 		if (isset($payload->{$displaynameAttribute})) {
 			$newDisplayName = mb_substr($payload->{$displaynameAttribute}, 0, 255);
-			$event = new AttributeMappedEvent(ProviderService::SETTING_MAPPING_DISPLAYNAME, $newDisplayName);
+			$event = new AttributeMappedEvent(ProviderService::SETTING_MAPPING_DISPLAYNAME, $payload, $newDisplayName);
 			$this->eventDispatcher->dispatchTyped($event);
 			$newDisplayName = $event->getValue();
 
@@ -287,7 +287,7 @@ class LoginController extends Controller {
 		// Update e-mail
 		$emailAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_EMAIL, 'email');
 		if (isset($payload->{$emailAttribute})) {
-			$event = new AttributeMappedEvent(ProviderService::SETTING_MAPPING_EMAIL, $payload->{$emailAttribute});
+			$event = new AttributeMappedEvent(ProviderService::SETTING_MAPPING_EMAIL, $payload, $payload->{$emailAttribute});
 			$this->eventDispatcher->dispatchTyped($event);
 			$this->logger->debug('Updating e-mail');
 			$user->setEMailAddress($event->getValue());
@@ -295,7 +295,7 @@ class LoginController extends Controller {
 
 		$quotaAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_QUOTA, 'quota');
 		if (isset($payload->{$quotaAttribute})) {
-			$event = new AttributeMappedEvent(ProviderService::SETTING_MAPPING_QUOTA, $payload->{$quotaAttribute});
+			$event = new AttributeMappedEvent(ProviderService::SETTING_MAPPING_QUOTA, $payload, $payload->{$quotaAttribute});
 			$this->eventDispatcher->dispatchTyped($event);
 			$user->setQuota($event->getValue());
 		}

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -164,13 +164,12 @@ class LoginController extends Controller {
 		}
 
 		//TODO verify discovery
-		if (isset($provider->getCustomQuery())) {
-			// if the request needs some additional query parameters
-			$url = $discovery['authorization_endpoint'] . '?' . http_build_query($data) . "&" . $provider->getCustomQuery();
-		} else {
-			$url = $discovery['authorization_endpoint'] . '?' . http_build_query($data);
-		}
-
+		
+		// compose url evey if a compley endpoint url format is given
+		$url = http_build_url($discovery['authorization_endpoint'],
+							  array(
+								  query => http_build_query($data)
+							  ), HTTP_URL_JOIN_QUERY);
 		$this->logger->debug('Redirecting user to: ' . $url);
 
 		return new RedirectResponse($url);

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace OCA\UserOIDC\Controller;
 
 use OCA\UserOIDC\Event\AttributeMappedEvent;
+use OCA\UserOIDC\Event\TokenObtainedEvent;
 use OCA\UserOIDC\Service\ProviderService;
 use OCA\UserOIDC\Vendor\Firebase\JWT\JWK;
 use OCA\UserOIDC\Vendor\Firebase\JWT\JWT;
@@ -172,7 +173,7 @@ class LoginController extends Controller {
 		}
 
 		//TODO verify discovery
-		
+
 		$url = $discovery['authorization_endpoint'] . '?' . http_build_query($data);
 		$this->logger->debug('Redirecting user to: ' . $url);
 
@@ -219,6 +220,7 @@ class LoginController extends Controller {
 		);
 
 		$data = json_decode($result->getBody(), true);
+		$this->eventDispatcher->dispatchTyped(new TokenObtainedEvent($data, $provider, $discovery));
 
 		// Obtain jwks
 		$client = $this->clientService->newClient();

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -149,6 +149,14 @@ class LoginController extends Controller {
 			'state' => $state,
 			'nonce' => $nonce,
 		];
+		// pass discovery query parameters also on to the authentication
+		$discoveryUrl = parse_url( $provider->getDiscoveryEndpoint());
+		if (isset($discoveryUrl["query"])) {
+			$this->logger->debug('Add custom discovery query: ' . $discoveryUrl["query"]);
+			$discoveryQuery = [];
+			parse_str($discoveryUrl["query"], $discoveryQuery);
+			$data += $discoveryQuery;
+		}
 
 		try {
 			$discovery = $this->obtainDiscovery($provider->getDiscoveryEndpoint());
@@ -165,11 +173,7 @@ class LoginController extends Controller {
 
 		//TODO verify discovery
 		
-		// compose url evey if a compley endpoint url format is given
-		$url = http_build_url($discovery['authorization_endpoint'],
-							  array(
-								  query => http_build_query($data)
-							  ), HTTP_URL_JOIN_QUERY);
+		$url = $discovery['authorization_endpoint'] . '?' . http_build_query($data);
 		$this->logger->debug('Redirecting user to: ' . $url);
 
 		return new RedirectResponse($url);

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -150,7 +150,7 @@ class LoginController extends Controller {
 			'nonce' => $nonce,
 		];
 		// pass discovery query parameters also on to the authentication
-		$discoveryUrl = parse_url( $provider->getDiscoveryEndpoint());
+		$discoveryUrl = parse_url($provider->getDiscoveryEndpoint());
 		if (isset($discoveryUrl["query"])) {
 			$this->logger->debug('Add custom discovery query: ' . $discoveryUrl["query"]);
 			$discoveryQuery = [];
@@ -272,7 +272,7 @@ class LoginController extends Controller {
 		// Update displayname
 		$displaynameAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_DISPLAYNAME, 'name');
 		if (isset($payload->{$displaynameAttribute})) {
-            $newDisplayName = mb_substr($payload->{$displaynameAttribute}, 0, 255);
+			$newDisplayName = mb_substr($payload->{$displaynameAttribute}, 0, 255);
 			$event = new AttributeMappedEvent(ProviderService::SETTING_MAPPING_DISPLAYNAME, $payload, $newDisplayName);
 		} else {
 			$event = new AttributeMappedEvent(ProviderService::SETTING_MAPPING_DISPLAYNAME, $payload);
@@ -282,7 +282,7 @@ class LoginController extends Controller {
 		if ($event->hasValue()) {
 			$newDisplayName = $event->getValue();
 			if ($newDisplayName != $backendUser->getDisplayName()) {
-			 	$backendUser->setDisplayName($newDisplayName);
+				$backendUser->setDisplayName($newDisplayName);
 				$backendUser = $this->userMapper->update($backendUser);
 			}
 		}
@@ -292,7 +292,7 @@ class LoginController extends Controller {
 		$event = new AttributeMappedEvent(ProviderService::SETTING_MAPPING_EMAIL, $payload, $payload->{$emailAttribute});
 		$this->eventDispatcher->dispatchTyped($event);
 		$this->logger->debug('Email dispatched');
-  	    if ($event->hasValue()) {
+		if ($event->hasValue()) {
 			$user->setEMailAddress($event->getValue());
 		}
 

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -295,14 +295,12 @@ class LoginController extends Controller {
 		}
 
 		$quotaAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_QUOTA, 'quota');
-		if (isset($payload->{$quotaAttribute})) {
-			$event = new AttributeMappedEvent(ProviderService::SETTING_MAPPING_QUOTA, $payload, $payload->{$quotaAttribute});
-		} else {
-			$event = new AttributeMappedEvent(ProviderService::SETTING_MAPPING_QUOTA, $payload, '');
-		}
+		$event = new AttributeMappedEvent(ProviderService::SETTING_MAPPING_QUOTA, $payload, $payload->{$quotaAttribute});
 		$this->eventDispatcher->dispatch(AttributeMappedEvent::class, $event);
 		$this->logger->debug('Quota dispatched');
-		$user->setQuota($event->getValue());
+		if ($event->hasValue()) {
+			$user->setQuota($event->getValue());
+		}
 
 		$this->logger->debug('Logging user in');
 

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -257,7 +257,7 @@ class LoginController extends Controller {
 		$uidAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_UID, 'sub');
 		$event = new AttributeMappedEvent(ProviderService::SETTING_MAPPING_UID, $payload, $payload->{$uidAttribute});
 		$this->eventDispatcher->dispatchTyped($event);
-		if ($event->hasValue()) {
+		if (!$event->hasValue()) {
 			return new JSONResponse($payload);
 		}
 

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -264,6 +264,11 @@ class LoginController extends Controller {
 
 		$this->logger->debug('User obtained: ' . $backendUser->getUserId());
 
+		$user = $this->userManager->get($backendUser->getUserId());
+		if ($user === null) {
+			return new JSONResponse(['Failed to provision user']);
+		}
+
 		// Update displayname
 		$displaynameAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_DISPLAYNAME, 'name');
 		if (isset($payload->{$displaynameAttribute})) {
@@ -273,16 +278,10 @@ class LoginController extends Controller {
 			$newDisplayName = $event->getValue();
 
 			if ($newDisplayName != $backendUser->getDisplayName()) {
-				$backendUser->setDisplayName($payload->{$displaynameAttribute});
+			 	$backendUser->setDisplayName($newDisplayName);
 				$backendUser = $this->userMapper->update($backendUser);
-
-				//TODO: dispatch event for the update
+			 	//TODO: dispatch event for the update
 			}
-		}
-
-		$user = $this->userManager->get($backendUser->getUserId());
-		if ($user === null) {
-			return new JSONResponse(['Failed to provision user']);
 		}
 
 		// Update e-mail

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -59,7 +59,7 @@ class SettingsController extends Controller {
 	}
 
 	public function createProvider(string $identifier, string $clientId, string $clientSecret, string $discoveryEndpoint, 
-                                   array $settings = [], string $scope ="openid email profile", string $customQuery = null ): JSONResponse {
+                                   array $settings = [], string $scope ="openid email profile"): JSONResponse {
 		if ($this->providerService->getProviderByIdentifier($identifier) !== null) {
 			return new JSONResponse(['message' => 'Provider with the given identifier already exists'], Http::STATUS_CONFLICT);
 		}
@@ -70,7 +70,6 @@ class SettingsController extends Controller {
 		$provider->setClientSecret($clientSecret);
 		$provider->setDiscoveryEndpoint($discoveryEndpoint);
 		$provider->setScope($scope);
-		$provider->setScope($customQuery);
 		$provider = $this->providerMapper->insert($provider);
 
 		$providerSettings = $this->providerService->setSettings($provider->getId(), $settings);
@@ -79,7 +78,7 @@ class SettingsController extends Controller {
 	}
 
 	public function updateProvider(int $providerId, string $identifier, string $clientId, string $discoveryEndpoint, string $clientSecret = null, 
-                                   array $settings = [], string $scope ="openid email profile", string $customQuery = null): JSONResponse {
+                                   array $settings = [], string $scope ="openid email profile"): JSONResponse {
 		$provider = $this->providerMapper->getProvider($providerId);
 
 		if ($this->providerService->getProviderByIdentifier($identifier) === null) {
@@ -91,12 +90,8 @@ class SettingsController extends Controller {
 		if ($clientSecret) {
 			$provider->setClientSecret($clientSecret);
 		}
-		if ($customQuery) {
-			$provider->setCustomQuery($customQuery);
-		}
 		$provider->setDiscoveryEndpoint($discoveryEndpoint);
-		$provider->setScope($scope;
-
+		$provider->setScope($scope);
 		$provider = $this->providerMapper->update($provider);
 
 		$providerSettings = $this->providerService->setSettings($providerId, $settings);

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -58,7 +58,8 @@ class SettingsController extends Controller {
 		$this->providerService = $providerService;
 	}
 
-	public function createProvider(string $identifier, string $clientId, string $clientSecret, string $discoveryEndpoint, array $settings = []): JSONResponse {
+	public function createProvider(string $identifier, string $clientId, string $clientSecret, string $discoveryEndpoint, 
+                                   array $settings = [], string $scope ="openid email profile", string $customQuery = null ): JSONResponse {
 		if ($this->providerService->getProviderByIdentifier($identifier) !== null) {
 			return new JSONResponse(['message' => 'Provider with the given identifier already exists'], Http::STATUS_CONFLICT);
 		}
@@ -68,6 +69,8 @@ class SettingsController extends Controller {
 		$provider->setClientId($clientId);
 		$provider->setClientSecret($clientSecret);
 		$provider->setDiscoveryEndpoint($discoveryEndpoint);
+		$provider->setScope($scope);
+		$provider->setScope($customQuery);
 		$provider = $this->providerMapper->insert($provider);
 
 		$providerSettings = $this->providerService->setSettings($provider->getId(), $settings);
@@ -75,7 +78,8 @@ class SettingsController extends Controller {
 		return new JSONResponse(array_merge($provider->jsonSerialize(), ['settings' => $providerSettings]));
 	}
 
-	public function updateProvider(int $providerId, string $identifier, string $clientId, string $discoveryEndpoint, string $clientSecret = null, array $settings = []): JSONResponse {
+	public function updateProvider(int $providerId, string $identifier, string $clientId, string $discoveryEndpoint, string $clientSecret = null, 
+                                   array $settings = [], string $scope ="openid email profile", string $customQuery = null): JSONResponse {
 		$provider = $this->providerMapper->getProvider($providerId);
 
 		if ($this->providerService->getProviderByIdentifier($identifier) === null) {
@@ -87,7 +91,11 @@ class SettingsController extends Controller {
 		if ($clientSecret) {
 			$provider->setClientSecret($clientSecret);
 		}
+		if ($customQuery) {
+			$provider->setCustomQuery($customQuery);
+		}
 		$provider->setDiscoveryEndpoint($discoveryEndpoint);
+		$provider->setScope($scope;
 
 		$provider = $this->providerMapper->update($provider);
 

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -58,8 +58,8 @@ class SettingsController extends Controller {
 		$this->providerService = $providerService;
 	}
 
-	public function createProvider(string $identifier, string $clientId, string $clientSecret, string $discoveryEndpoint, 
-                                   array $settings = [], string $scope ="openid email profile"): JSONResponse {
+	public function createProvider(string $identifier, string $clientId, string $clientSecret, string $discoveryEndpoint,
+								   array $settings = [], string $scope = "openid email profile"): JSONResponse {
 		if ($this->providerService->getProviderByIdentifier($identifier) !== null) {
 			return new JSONResponse(['message' => 'Provider with the given identifier already exists'], Http::STATUS_CONFLICT);
 		}
@@ -77,8 +77,8 @@ class SettingsController extends Controller {
 		return new JSONResponse(array_merge($provider->jsonSerialize(), ['settings' => $providerSettings]));
 	}
 
-	public function updateProvider(int $providerId, string $identifier, string $clientId, string $discoveryEndpoint, string $clientSecret = null, 
-                                   array $settings = [], string $scope ="openid email profile"): JSONResponse {
+	public function updateProvider(int $providerId, string $identifier, string $clientId, string $discoveryEndpoint, string $clientSecret = null,
+								   array $settings = [], string $scope = "openid email profile"): JSONResponse {
 		$provider = $this->providerMapper->getProvider($providerId);
 
 		if ($this->providerService->getProviderByIdentifier($identifier) === null) {

--- a/lib/Db/Provider.php
+++ b/lib/Db/Provider.php
@@ -36,6 +36,10 @@ use OCP\AppFramework\Db\Entity;
  * @method void setClientSecret(string $clientSecret)
  * @method string getDiscoveryEndpoint()
  * @method void setDiscoveryEndpoint(string $discoveryEndpoint)
+ * @method string getScope()
+ * @method void setScope(string $scope)
+ * @method string getCustomQuery()
+ * @method void setCustomQuery(string $customQuery)
  */
 class Provider extends Entity implements \JsonSerializable {
 
@@ -51,12 +55,20 @@ class Provider extends Entity implements \JsonSerializable {
 	/** @var string */
 	protected $discoveryEndpoint;
 
+	/** @var string */
+	protected $scope;
+
+	/** @var string */
+	protected $customQuery;
+
 	public function jsonSerialize() {
 		return [
 			'id' => $this->id,
 			'identifier' => $this->identifier,
 			'clientId' => $this->clientId,
 			'discoveryEndpoint' => $this->discoveryEndpoint,
+			'scope' => scope,
+			'customQuery' => $this->customQuery
 		];
 	}
 }

--- a/lib/Db/Provider.php
+++ b/lib/Db/Provider.php
@@ -38,8 +38,6 @@ use OCP\AppFramework\Db\Entity;
  * @method void setDiscoveryEndpoint(string $discoveryEndpoint)
  * @method string getScope()
  * @method void setScope(string $scope)
- * @method string getCustomQuery()
- * @method void setCustomQuery(string $customQuery)
  */
 class Provider extends Entity implements \JsonSerializable {
 

--- a/lib/Db/Provider.php
+++ b/lib/Db/Provider.php
@@ -58,9 +58,6 @@ class Provider extends Entity implements \JsonSerializable {
 	/** @var string */
 	protected $scope;
 
-	/** @var string */
-	protected $customQuery;
-
 	public function jsonSerialize() {
 		return [
 			'id' => $this->id,
@@ -68,7 +65,6 @@ class Provider extends Entity implements \JsonSerializable {
 			'clientId' => $this->clientId,
 			'discoveryEndpoint' => $this->discoveryEndpoint,
 			'scope' => scope,
-			'customQuery' => $this->customQuery
 		];
 	}
 }

--- a/lib/Db/Provider.php
+++ b/lib/Db/Provider.php
@@ -64,7 +64,7 @@ class Provider extends Entity implements \JsonSerializable {
 			'identifier' => $this->identifier,
 			'clientId' => $this->clientId,
 			'discoveryEndpoint' => $this->discoveryEndpoint,
-			'scope' => scope,
+			'scope' => $this->scope,
 		];
 	}
 }

--- a/lib/Db/ProviderMapper.php
+++ b/lib/Db/ProviderMapper.php
@@ -92,7 +92,6 @@ class ProviderMapper extends QBMapper {
 	 * @param string|null $clientid
 	 * @param string|null $clientsecret
 	 * @param string|null $discoveryuri
-	 * @param string|null $customquery
 	 * @param string scope
 	 * @throws \OCP\AppFramework\Db\DoesNotExistException
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException

--- a/lib/Db/ProviderMapper.php
+++ b/lib/Db/ProviderMapper.php
@@ -99,7 +99,7 @@ class ProviderMapper extends QBMapper {
 	 */
 	public function createOrUpdateProvider(string $identifier, string $clientid = null,
 									string $clientsecret = null, string $discoveryuri = null,
-									string $customquery = null, string $scope = 'openid email profile') {
+									string $scope = 'openid email profile') {
 		try {
 			$provider = $this->findProviderByIdentifier($identifier);
 		} catch (DoesNotExistException $eNotExist) {
@@ -116,7 +116,6 @@ class ProviderMapper extends QBMapper {
 			$provider->setClientSecret($clientsecret);
 			$provider->setDiscoveryEndpoint($discoveryuri);
 			$provider->setScope($scope);
-			$provider->setCustomQuery($customquery);
 			return $this->insert($provider);
 		} else {
 			if ($clientid !== null) {
@@ -127,9 +126,6 @@ class ProviderMapper extends QBMapper {
 			}
 			if ($discoveryuri !== null) {
 				$provider->setDiscoveryEndpoint($discoveryuri);
-			}
-			if ($customquery !== null) {
-				$provider->setCustomQuery($customquery);
 			}
 			$provider->setScope($scope);
 			return $this->update($provider);

--- a/lib/Db/ProviderMapper.php
+++ b/lib/Db/ProviderMapper.php
@@ -92,11 +92,14 @@ class ProviderMapper extends QBMapper {
 	 * @param string|null $clientid
 	 * @param string|null $clientsecret
 	 * @param string|null $discoveryuri
+	 * @param string|null $customquery
+	 * @param string scope
 	 * @throws \OCP\AppFramework\Db\DoesNotExistException
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
 	 */
 	public function createOrUpdateProvider(string $identifier, string $clientid = null,
-									string $clientsecret = null, string $discoveryuri = null) {
+									string $clientsecret = null, string $discoveryuri = null,
+									string $customquery = null, string $scope = 'openid email profile') {
 		try {
 			$provider = $this->findProviderByIdentifier($identifier);
 		} catch (DoesNotExistException $eNotExist) {
@@ -112,6 +115,8 @@ class ProviderMapper extends QBMapper {
 			$provider->setClientId($clientid);
 			$provider->setClientSecret($clientsecret);
 			$provider->setDiscoveryEndpoint($discoveryuri);
+			$provider->setScope($scope);
+			$provider->setCustomQuery($customquery);
 			return $this->insert($provider);
 		} else {
 			if ($clientid !== null) {
@@ -123,6 +128,10 @@ class ProviderMapper extends QBMapper {
 			if ($discoveryuri !== null) {
 				$provider->setDiscoveryEndpoint($discoveryuri);
 			}
+			if ($customquery !== null) {
+				$provider->setCustomQuery($customquery);
+			}
+			$provider->setScope($scope);
 			return $this->update($provider);
 		}
 	}

--- a/lib/Event/AttributeMappedEvent.php
+++ b/lib/Event/AttributeMappedEvent.php
@@ -1,0 +1,64 @@
+<?php
+/*
+ * @copyright Copyright (c) 2021 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+
+namespace OCA\UserOIDC\Event;
+
+use OCP\EventDispatcher\Event;
+
+/**
+ * Event to provide custom mapping logic based on the OIDC token data
+ * In order to avoid further processing the event propagation should be stopped
+ * in the listener after processing as the value might get overwritten afterwards
+ * by other listeners through $event->stopPropagation();
+ */
+class AttributeMappedEvent extends Event {
+
+	/** @var string */
+	private $attribute;
+	/** @var string */
+	private $value;
+
+	public function __construct(string $attribute, string $value) {
+		parent::__construct();
+		$this->attribute = $attribute;
+		$this->value = $value;
+	}
+
+	/**
+	 * @return string One of the ProviderService::SETTING_MAPPING_* constants for the attribute mapping that is currently processed
+	 */
+	public function getAttribute(): string {
+		return $this->attribute;
+	}
+
+	public function getValue(): string {
+		return $this->value;
+	}
+
+	public function setValue(string $value): void {
+		$this->value = $value;
+	}
+}

--- a/lib/Event/AttributeMappedEvent.php
+++ b/lib/Event/AttributeMappedEvent.php
@@ -39,13 +39,18 @@ class AttributeMappedEvent extends Event {
 	/** @var string */
 	private $attribute;
 	/** @var string */
+	private $claims;
+	/** @var string */
 	private $value;
 
-	public function __construct(string $attribute, string $value) {
+	public function __construct(string $attribute, array $claims, string $default) {
 		parent::__construct();
 		$this->attribute = $attribute;
-		$this->value = $value;
+		$this->claims = $claims;
+		$this->value = $default;
 	}
+
+
 
 	/**
 	 * @return string One of the ProviderService::SETTING_MAPPING_* constants for the attribute mapping that is currently processed
@@ -54,6 +59,16 @@ class AttributeMappedEvent extends Event {
 		return $this->attribute;
 	}
 
+	/**
+	 * @return array the array of claim values associated with the event
+	 */
+	public function getClaims(): array {
+		return $this->claims;
+	}
+
+	/**
+	 * @return value for the logged in user attribute
+	 */
 	public function getValue(): string {
 		return $this->value;
 	}

--- a/lib/Event/AttributeMappedEvent.php
+++ b/lib/Event/AttributeMappedEvent.php
@@ -43,7 +43,7 @@ class AttributeMappedEvent extends Event {
 	/** @var string */
 	private $value;
 
-	public function __construct(string $attribute, object $claims, string $default) {
+	public function __construct(string $attribute, object $claims, ?string $default = null) {
 		parent::__construct();
 		$this->attribute = $attribute;
 		$this->claims = $claims;
@@ -64,14 +64,18 @@ class AttributeMappedEvent extends Event {
 		return $this->claims;
 	}
 
+	public function hasValue() : bool {
+		return ($this->value != null);
+	}
+
 	/**
 	 * @return value for the logged in user attribute
 	 */
-	public function getValue(): string {
+	public function getValue(): ?string {
 		return $this->value;
 	}
 
-	public function setValue(string $value): void {
+	public function setValue(?string $value): void {
 		$this->value = $value;
 	}
 }

--- a/lib/Event/AttributeMappedEvent.php
+++ b/lib/Event/AttributeMappedEvent.php
@@ -60,7 +60,7 @@ class AttributeMappedEvent extends Event {
 	/**
 	 * @return array the array of claim values associated with the event
 	 */
-	public function getClaims(): array {
+	public function getClaims(): object {
 		return $this->claims;
 	}
 

--- a/lib/Event/AttributeMappedEvent.php
+++ b/lib/Event/AttributeMappedEvent.php
@@ -38,19 +38,17 @@ class AttributeMappedEvent extends Event {
 
 	/** @var string */
 	private $attribute;
-	/** @var string */
+	/** @var object */
 	private $claims;
 	/** @var string */
 	private $value;
 
-	public function __construct(string $attribute, array $claims, string $default) {
+	public function __construct(string $attribute, object $claims, string $default) {
 		parent::__construct();
 		$this->attribute = $attribute;
 		$this->claims = $claims;
 		$this->value = $default;
 	}
-
-
 
 	/**
 	 * @return string One of the ProviderService::SETTING_MAPPING_* constants for the attribute mapping that is currently processed

--- a/lib/Event/TokenObtainedEvent.php
+++ b/lib/Event/TokenObtainedEvent.php
@@ -1,0 +1,60 @@
+<?php
+/*
+ * @copyright Copyright (c) 2021 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+namespace OCA\UserOIDC\Event;
+
+use OCA\UserOIDC\Db\Provider;
+use OCP\EventDispatcher\Event;
+
+/**
+ * This event is emitted with the raw token information that is returned to the code endpoint
+ *
+ * It may be used for further handling of oidc authenticated requests
+ */
+class TokenObtainedEvent extends Event {
+	private $token;
+	private $provider;
+	private $discovery;
+
+	public function __construct(array $token, $provider, $discovery) {
+		parent::__construct();
+
+		$this->token = $token;
+		$this->provider = $provider;
+		$this->discovery = $discovery;
+	}
+
+	public function getToken(): array {
+		return $this->token;
+	}
+
+	public function getProvider(): Provider {
+		return $this->provider;
+	}
+
+	public function getDiscovery(): array {
+		return $this->discovery;
+	}
+}

--- a/lib/Migration/Version00007Date20210730170713.php
+++ b/lib/Migration/Version00007Date20210730170713.php
@@ -20,13 +20,6 @@ class Version00007Date20210730170713 extends SimpleMigrationStep {
 			'default' => 'openid email profile',
 			'notnull' => true,
 		]);
-		$table->addColumn('custom_query', 'string', [
-			'length' => 255,
-			'default' => '',
-			'notnull' => false,
-		]);
-
-
 
 		return $schema;
 	}

--- a/lib/Migration/Version00007Date20210730170713.php
+++ b/lib/Migration/Version00007Date20210730170713.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\UserOIDC\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version00007Date20210730170713 extends SimpleMigrationStep {
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('user_oidc');
+		$table->addColumn('scope', 'string', [
+			'length' => 128,
+			'default' => 'openid email profile',
+			'notnull' => true,
+		]);
+		$table->addColumn('custom_query', 'string', [
+			'length' => 255,
+			'default' => '',
+			'notnull' => false,
+		]);
+
+
+
+		return $schema;
+	}
+}

--- a/lib/Migration/Version00007Date20210730170713.php
+++ b/lib/Migration/Version00007Date20210730170713.php
@@ -14,7 +14,7 @@ class Version00007Date20210730170713 extends SimpleMigrationStep {
 		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 
-		$table = $schema->getTable('user_oidc');
+		$table = $schema->getTable('user_oidc_providers');
 		$table->addColumn('scope', 'string', [
 			'length' => 128,
 			'default' => 'openid email profile',

--- a/src/components/SettingsForm.vue
+++ b/src/components/SettingsForm.vue
@@ -54,11 +54,11 @@
 				required>
 		</p>
 		<p>
-			<label for="oidc-scope">{{ t('user_oidc', 'Scope') }}</label>
+			<label for="oidc-scopr">{{ t('user_oidc', 'Scope') }}</label>
 			<input id="oidc-scope"
 				v-model="localProvider.scope"
 				type="text"
-				:placeholder="openid email profile">
+				placeholder="openid email profile">
 		</p>
 		<h4>{{ t('user_oidc', 'Attribute mapping') }}</h4>
 		<p>

--- a/src/components/SettingsForm.vue
+++ b/src/components/SettingsForm.vue
@@ -60,13 +60,6 @@
 				type="text"
 				:placeholder="openid email profile">
 		</p>
-		<p>
-			<label for="oidc-custom-query">{{ t('user_oidc', 'Custom query') }}</label>
-			<input id="oidc-discovery-endpoint"
-				v-model="localProvider.customQuery"
-				type="text"
-				:placeholder="t('user_oidc', 'Optional custom query')">
-		</p>
 		<h4>{{ t('user_oidc', 'Attribute mapping') }}</h4>
 		<p>
 			<label for="mapping-uid">{{ t('user_oidc', 'User ID mapping') }}</label>

--- a/src/components/SettingsForm.vue
+++ b/src/components/SettingsForm.vue
@@ -54,7 +54,7 @@
 				required>
 		</p>
 		<p>
-			<label for="oidc-scopr">{{ t('user_oidc', 'Scope') }}</label>
+			<label for="oidc-scope">{{ t('user_oidc', 'Scope') }}</label>
 			<input id="oidc-scope"
 				v-model="localProvider.scope"
 				type="text"

--- a/src/components/SettingsForm.vue
+++ b/src/components/SettingsForm.vue
@@ -53,6 +53,20 @@
 				type="text"
 				required>
 		</p>
+		<p>
+			<label for="oidc-scope">{{ t('user_oidc', 'Scope') }}</label>
+			<input id="oidc-scope"
+				v-model="localProvider.scope"
+				type="text"
+				:placeholder="openid email profile">
+		</p>
+		<p>
+			<label for="oidc-custom-query">{{ t('user_oidc', 'Custom query') }}</label>
+			<input id="oidc-discovery-endpoint"
+				v-model="localProvider.customQuery"
+				type="text"
+				:placeholder="t('user_oidc', 'Optional custom query')">
+		</p>
 		<h4>{{ t('user_oidc', 'Attribute mapping') }}</h4>
 		<p>
 			<label for="mapping-uid">{{ t('user_oidc', 'User ID mapping') }}</label>

--- a/tests/unit/Service/ProviderServiceTest.php
+++ b/tests/unit/Service/ProviderServiceTest.php
@@ -74,6 +74,7 @@ class ProviderServiceTest extends TestCase {
 				'identifier' => null,
 				'clientId' => null,
 				'discoveryEndpoint' => null,
+				'scope' => null,
 				'settings' => [
 					'mappingDisplayName' => '1',
 					'mappingEmail' => '1',
@@ -87,6 +88,7 @@ class ProviderServiceTest extends TestCase {
 				'identifier' => null,
 				'clientId' => null,
 				'discoveryEndpoint' => null,
+				'scope' => null,
 				'settings' => [
 					'mappingDisplayName' => '1',
 					'mappingEmail' => '1',


### PR DESCRIPTION
This pull request contains an extension that has been needed to integrate with a big, corporate identity management system.

## Part 1: Support OpenId connect claims
OpenID connect claims define a set of attributes that is passes together with the token back to the client that is requesting authorisation. A client can select the attribute sets in its request to IDM by listing attribute profile names in`scope` field 
The `scope` field is added to the Provider configuration and defaults to `openid email profile'

## Part 2: Complex mapping rules coded with events
Before a field in user account is filled with the mapped field in the token, the value of the token is published as `AttributeMappedEvent`. The event contains all claims as event payload, as well as the value of the mapped source claim in token. If the mapped claim does not exist in token, the `null` value is set as default in event.

The `AttributeMappedEvent::handle(Event $event)` can implement complex code for rules based on multiple claims and pass back the result by `setValue`. With using the event system, the rules can be implemented in a separate app which decouples business rule logic from `user_oidc` technical code.

If the value of an event is `null`and there is no directly mapped field value available, the field in user account is not set.

## Part 3: query parameters for discovered `token_endpoint`
For some developers, it is tempting to extend functionality of the IDM `token_endpoint` by introducing custom query parameter. This is not good for a standard OpenID connect client implementation, as the `token_endpoint` is called as a second step after `discovery` of the OPenId connect endpoints. To support such query parameters and not implement a `custom`case for it. the `discovery_url` can be configured in provider with query parameters. The query is send with the discover AND with the token endpoint. This usually works well because custom query parameter can usually be send to discovery endpoint but are ignored there. After discovery, the same query parameters are again send to `token_endpoint`and accepted there.
