### PR TITLE
Bearer token validation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -38,6 +38,7 @@ use OCP\IUserSession;
 
 class Application extends App {
 	public const APP_ID = 'user_oidc';
+	public const OIDC_API_REQ_HEADER = 'Authorization';
 
 	public function __construct(array $urlParams = []) {
 		parent::__construct(self::APP_ID, $urlParams);
@@ -51,7 +52,9 @@ class Application extends App {
 		$userManager = $this->getContainer()->query(IUserManager::class);
 
 		/* Register our own user backend */
-		$userManager->registerBackend($this->getContainer()->query(Backend::class));
+		$backend = $this->getContainer()->query(Backend::class);
+		$userManager->registerBackend($backend);
+		\OC_User::useBackend($backend);
 
 		if (!$userSession->isLoggedIn()) {
 

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -102,7 +102,6 @@ class Application extends App {
 					'href' => $urlGenerator->linkToRoute(self::APP_ID . '.id4me.login'),
 				]);
 			}
-			return;
 		}
 	}
 }

--- a/lib/Command/UpsertProvider.php
+++ b/lib/Command/UpsertProvider.php
@@ -58,6 +58,7 @@ class UpsertProvider extends Command {
 
 			->addOption('scope', 'o', InputOption::VALUE_OPTIONAL, 'OpenID requested value scopes, if not set defaults to "openid email profile"')
 			->addOption('unique-uid', null, InputOption::VALUE_OPTIONAL, 'Flag if unique user ids shall be used or not. 1 to enable (default), 0 to disable.')
+			->addOption('check-bearer', null, InputOption::VALUE_OPTIONAL, 'Flag if Nextcloud API/WebDav calls should check the Bearer token against this provider or not. 1 to enable (default), 0 to disable.')
 			->addOption('mapping-display-name', null, InputOption::VALUE_OPTIONAL, 'Attribute mapping of the display name')
 			->addOption('mapping-email', null, InputOption::VALUE_OPTIONAL, 'Attribute mapping of the email address')
 			->addOption('mapping-quota', null, InputOption::VALUE_OPTIONAL, 'Attribute mapping of the quota')
@@ -90,7 +91,7 @@ class UpsertProvider extends Command {
 		$updateOptions = array_filter($input->getOptions(), static function ($value, $option) {
 			return in_array($option, [
 				'identifier', 'clientid', 'clientsecret', 'discoveryuri',
-				'scope', 'unique-uid',
+				'scope', 'unique-uid', 'check-bearer',
 				'mapping-uid', 'mapping-display-name', 'mapping-email', 'mapping-quota',
 			]) && $value !== null;
 		}, ARRAY_FILTER_USE_BOTH);
@@ -129,6 +130,9 @@ class UpsertProvider extends Command {
 		} catch (DoesNotExistException | MultipleObjectsReturnedException $e) {
 			$output->writeln('<error>' . $e->getMessage() . '</error>');
 			return -1;
+		}
+		if (($checkBearer = $input->getOption('check-bearer')) !== null) {
+			$this->providerService->setSetting($provider->getId(), ProviderService::SETTING_CHECK_BEARER, (string)$checkBearer === '0' ? '0' : '1');
 		}
 		if (($uniqueUid = $input->getOption('unique-uid')) !== null) {
 			$this->providerService->setSetting($provider->getId(), ProviderService::SETTING_UNIQUE_UID, (string)$uniqueUid === '0' ? '0' : '1');

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -142,21 +142,34 @@ class LoginController extends Controller {
 		$this->session->set(self::PROVIDERID, $providerId);
 		$this->session->close();
 
+		// get attribute mapping settings
+		$uidAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_UID, 'sub');
+		$emailAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_EMAIL, 'email');
+		$displaynameAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_DISPLAYNAME, 'name');
+		$quotaAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_QUOTA, 'quota');
+
 		$data = [
 			'client_id' => $provider->getClientId(),
 			'response_type' => 'code',
 			'scope' => $provider->getScope(),
 			'redirect_uri' => $this->urlGenerator->linkToRouteAbsolute(Application::APP_ID . '.login.code'),
 			'claims' => json_encode([
+				// more details about requesting claims:
+				// https://openid.net/specs/openid-connect-core-1_0.html#IndividualClaimsRequests
 				'id_token' => [
-					'preferred_username' => ['essential' => true],
-					'name' => ['essential' => true],
-					'email' => ['essential' => true],
-					'quota' => ['essential' => true],
+					// ['essential' => true] means it's mandatory but it won't trigger an error if it's not there
+					$uidAttribute => ['essential' => true],
+					// null means we want it
+					$emailAttribute => null,
+					$displaynameAttribute => null,
+					$quotaAttribute => null,
 				],
-				//'userinfo' => [
-				//	'preferred_username' => ['essential' => true],
-				//],
+				'userinfo' => [
+					$uidAttribute => ['essential' => true],
+					$emailAttribute => null,
+					$displaynameAttribute => null,
+					$quotaAttribute => null,
+				],
 			]),
 			'state' => $state,
 			'nonce' => $nonce,
@@ -247,6 +260,11 @@ class LoginController extends Controller {
 		$payload = JWT::decode($data['id_token'], $jwks, array_keys(JWT::$supported_algs));
 
 		$this->logger->debug('Parsed the JWT payload: ' . json_encode($payload, JSON_THROW_ON_ERROR));
+
+		// access token debug
+		$payloadAcc = JWT::decode($data['access_token'], $jwks, array_keys(JWT::$supported_algs));
+		$prettyAccToken = json_encode($payloadAcc, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+		error_log('DECODED access TOKEN : '.$prettyAccToken);
 
 		if ($payload->exp < $this->timeFactory->getTime()) {
 			$this->logger->debug('Token expired');

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -26,6 +26,7 @@ declare(strict_types=1);
 namespace OCA\UserOIDC\Controller;
 
 use OCA\UserOIDC\Event\AttributeMappedEvent;
+use OCA\UserOIDC\Event\TokenObtainedEvent;
 use OCA\UserOIDC\Service\ProviderService;
 use OCA\UserOIDC\Vendor\Firebase\JWT\JWK;
 use OCA\UserOIDC\Vendor\Firebase\JWT\JWT;
@@ -172,7 +173,7 @@ class LoginController extends Controller {
 		}
 
 		//TODO verify discovery
-		
+
 		$url = $discovery['authorization_endpoint'] . '?' . http_build_query($data);
 		$this->logger->debug('Redirecting user to: ' . $url);
 
@@ -219,6 +220,7 @@ class LoginController extends Controller {
 		);
 
 		$data = json_decode($result->getBody(), true);
+		$this->eventDispatcher->dispatchTyped(new TokenObtainedEvent($data, $provider, $discovery));
 
 		// Obtain jwks
 		$client = $this->clientService->newClient();

--- a/lib/Event/TokenObtainedEvent.php
+++ b/lib/Event/TokenObtainedEvent.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * @copyright Copyright (c) 2021 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+namespace OCA\UserOIDC\Event;
+
+use OCA\UserOIDC\Db\Provider;
+use OCP\EventDispatcher\Event;
+
+/**
+ * This event is emitted with the raw token information that is returned to the code endpoint
+ *
+ * It may be used for further handling of oidc authenticated requests
+ */
+class TokenObtainedEvent extends Event {
+
+	private $token;
+	private $provider;
+	private $discovery;
+
+	public function __construct(array $token, $provider, $discovery) {
+		parent::__construct();
+
+		$this->token = $token;
+		$this->provider = $provider;
+		$this->discovery = $discovery;
+	}
+
+	public function getToken(): array {
+		return $this->token;
+	}
+
+	public function getProvider(): Provider {
+		return $this->provider;
+	}
+
+	public function getDiscovery(): array {
+		return $this->discovery;
+	}
+
+}

--- a/lib/Service/DiscoveryService.php
+++ b/lib/Service/DiscoveryService.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ * @copyright Copyright (c) 2021 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+namespace OCA\UserOIDC\Service;
+
+use OCA\UserOIDC\Db\Provider;
+use OCA\UserOIDC\Vendor\Firebase\JWT\JWK;
+use OCP\Http\Client\IClientService;
+use Psr\Log\LoggerInterface;
+
+class DiscoveryService {
+
+	/** @var LoggerInterface */
+	private $logger;
+
+	/** @var IClientService */
+	private $clientService;
+
+	public function __construct(LoggerInterface $logger, IClientService $clientService) {
+		$this->logger = $logger;
+		$this->clientService = $clientService;
+	}
+
+	public function obtainDiscovery(Provider $provider): array {
+		$url = $provider->getDiscoveryEndpoint();
+		$client = $this->clientService->newClient();
+
+		$this->logger->debug('Obtaining discovery endpoint: ' . $url);
+		$response = $client->get($url);
+
+		return json_decode($response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+	}
+
+	public function obtainJWK(Provider $provider): array {
+		$discovery = $this->obtainDiscovery($provider);
+		$client = $this->clientService->newClient();
+		$result = json_decode($client->get($discovery['jwks_uri'])->getBody(), true);
+		$jwks = JWK::parseKeySet($result);
+
+		$this->logger->debug('Parsed the jwks');
+		return $jwks;
+	}
+}

--- a/lib/Service/OIDCService.php
+++ b/lib/Service/OIDCService.php
@@ -1,0 +1,89 @@
+<?php
+/*
+ * @copyright Copyright (c) 2021 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+namespace OCA\UserOIDC\Service;
+
+use OCA\UserOIDC\Db\Provider;
+use OCP\Http\Client\IClientService;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+class OIDCService {
+
+	/** @var LoggerInterface */
+	private $logger;
+
+	/** @var IClientService */
+	private $clientService;
+
+	public function __construct(DiscoveryService $discoveryService, LoggerInterface $logger, IClientService $clientService) {
+		$this->discoveryService = $discoveryService;
+		$this->logger = $logger;
+		$this->clientService = $clientService;
+	}
+
+	public function userinfo(Provider $provider, string $accessToken): array {
+		$url = $this->discoveryService->obtainDiscovery($provider)['userinfo_endpoint'] ?? null;
+		if ($url === null) {
+			return [];
+		}
+
+		$client = $this->clientService->newClient();
+		$this->logger->debug('Fetching user info endpoint');
+		$options = [
+			'headers' => [
+				'Authorization' => 'Bearer ' . $accessToken,
+			],
+		];
+		try {
+			return json_decode($client->get($url, $options)->getBody(), true);
+		} catch (Throwable $e) {
+			return [];
+		}
+	}
+
+	public function introspection(Provider $provider, string $accessToken): array {
+		$url = $this->discoveryService->obtainDiscovery($provider)['introspection_endpoint'] ?? null;
+		if ($url === null) {
+			return [];
+		}
+
+		$client = $this->clientService->newClient();
+		$this->logger->debug('Fetching user info endpoint');
+		$options = [
+			'headers' => [
+				'Authorization' => base64_encode($provider->getClientId() . ':' . $provider->getClientSecret()),
+			],
+			'body' => [
+				'token' => $accessToken,
+			],
+		];
+		try {
+			return json_decode($client->post($url, $options)->getBody(), true);
+		} catch (Throwable $e) {
+			return [];
+		}
+	}
+}

--- a/lib/Service/ProviderService.php
+++ b/lib/Service/ProviderService.php
@@ -35,6 +35,7 @@ use OCP\IConfig;
 class ProviderService {
 	public const SETTING_UNIQUE_UID = 'uniqueUid';
 	public const SETTING_MAPPING_UID = 'mappingUid';
+	public const SETTING_MAPPING_UID_DEFAULT = 'sub';
 	public const SETTING_MAPPING_DISPLAYNAME = 'mappingDisplayName';
 	public const SETTING_MAPPING_EMAIL = 'mappingEmail';
 	public const SETTING_MAPPING_QUOTA = 'mappingQuota';

--- a/lib/Service/ProviderService.php
+++ b/lib/Service/ProviderService.php
@@ -33,6 +33,7 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IConfig;
 
 class ProviderService {
+	public const SETTING_CHECK_BEARER = 'checkBearer';
 	public const SETTING_UNIQUE_UID = 'uniqueUid';
 	public const SETTING_MAPPING_UID = 'mappingUid';
 	public const SETTING_MAPPING_UID_DEFAULT = 'sub';
@@ -121,19 +122,21 @@ class ProviderService {
 			self::SETTING_MAPPING_EMAIL,
 			self::SETTING_MAPPING_QUOTA,
 			self::SETTING_MAPPING_UID,
-			self::SETTING_UNIQUE_UID
+			self::SETTING_UNIQUE_UID,
+			self::SETTING_CHECK_BEARER,
 		];
 	}
 
 	private function convertFromJSON(string $key, $value): string {
-		if ($key === self::SETTING_UNIQUE_UID) {
+		if ($key === self::SETTING_UNIQUE_UID || $key === self::SETTING_CHECK_BEARER) {
 			$value = $value ? '1' : '0';
 		}
 		return (string)$value;
 	}
 
 	private function convertToJSON(string $key, $value) {
-		if ($key === self::SETTING_UNIQUE_UID) {
+		// default is disabled (if not set)
+		if ($key === self::SETTING_UNIQUE_UID || $key === self::SETTING_CHECK_BEARER) {
 			return $value === '1';
 		}
 		return (string)$value;

--- a/lib/User/Backend.php
+++ b/lib/User/Backend.php
@@ -26,24 +26,71 @@ declare(strict_types=1);
 namespace OCA\UserOIDC\User;
 
 use OCA\UserOIDC\AppInfo\Application;
+use OCA\UserOIDC\Db\ProviderMapper;
 use OCA\UserOIDC\Db\UserMapper;
+use OCA\UserOIDC\Service\ProviderService;
+use OCA\UserOIDC\Vendor\Firebase\JWT\JWK;
+use OCA\UserOIDC\Vendor\Firebase\JWT\JWT;
 use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Authentication\IApacheBackend;
 use OCP\DB\Exception;
+use OCP\Http\Client\IClient;
+use OCP\Http\Client\IClientService;
+use OCP\IRequest;
+use OCP\ISession;
 use OCP\User\Backend\ABackend;
 use OCP\User\Backend\IGetDisplayNameBackend;
 use OCP\User\Backend\IPasswordConfirmationBackend;
 use Psr\Log\LoggerInterface;
 
-class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisplayNameBackend {
+class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisplayNameBackend, IApacheBackend {
 
 	/** @var UserMapper */
 	private $userMapper;
 	/** @var LoggerInterface */
 	private $logger;
+	/**
+	 * @var ISession
+	 */
+	private $session;
+	/**
+	 * @var IRequest
+	 */
+	private $request;
+	/**
+	 * @var IClientService
+	 */
+	private $clientService;
+	/**
+	 * @var ProviderMapper
+	 */
+	private $providerMapper;
+	/**
+	 * @var ITimeFactory
+	 */
+	private $timeFactory;
+	/**
+	 * @var ProviderService
+	 */
+	private $providerService;
 
-	public function __construct(UserMapper $userMapper, LoggerInterface $logger) {
+	public function __construct(UserMapper $userMapper,
+								LoggerInterface $logger,
+								ISession $session,
+								IRequest $request,
+								ITimeFactory $timeFactory,
+								IClientService $clientService,
+								ProviderService $providerService,
+								ProviderMapper $providerMapper) {
 		$this->userMapper = $userMapper;
 		$this->logger = $logger;
+		$this->session = $session;
+		$this->request = $request;
+		$this->clientService = $clientService;
+		$this->providerMapper = $providerMapper;
+		$this->timeFactory = $timeFactory;
+		$this->providerService = $providerService;
 	}
 
 	public function getBackendName(): string {
@@ -91,5 +138,146 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 
 	public function canConfirmPassword(string $uid): bool {
 		return false;
+	}
+
+	/**
+	 * In case the user has been authenticated by Apache true is returned.
+	 *
+	 * @return boolean whether Apache reports a user as currently logged in.
+	 * @since 6.0.0
+	 */
+	public function isSessionActive() {
+		// if this returns true, getCurrentUserId is called
+		$headerToken = $this->request->getHeader(Application::OIDC_API_REQ_HEADER);
+		return $headerToken !== '';
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function getLogoutUrl() {
+		return '';
+	}
+
+	/**
+	 * Return the id of the current user
+	 * @return string
+	 * @since 6.0.0
+	 */
+	public function getCurrentUserId() {
+		// get the first provider
+		// TODO make sure this fits our needs and there never is more than one provider
+		$providers = $this->providerMapper->getProviders();
+		if (count($providers) > 0) {
+			$provider = $providers[0];
+		} else {
+			$this->logger->error('no OIDC providers');
+			return '';
+		}
+
+		// get attribute mapping settings
+		$uidAttribute = $this->providerService->getSetting($provider->getId(), ProviderService::SETTING_MAPPING_UID, 'sub');
+		$userId = null;
+
+		/*
+		 * try to decode the token
+		 * if valid:
+		 * 		if not expired and we find user ID mapping attr inside:
+		 * 			validate
+		 * 		else:
+		 * 			it might be an access token, try to use it to reach userinfo
+		 * else:
+		 * 		it might be an access token, try to use it to reach userinfo
+		 */
+
+		// get the JWKS from the provider
+		$discovery = $this->obtainDiscovery($provider->getDiscoveryEndpoint());
+		$client = $this->clientService->newClient();
+		$result = json_decode($client->get($discovery['jwks_uri'])->getBody(), true);
+		$this->logger->debug('Obtained the jwks');
+		$jwks = JWK::parseKeySet($result);
+		$this->logger->debug('Parsed the jwks');
+
+		// get the bearer token from headers
+		$headerToken = $this->request->getHeader(Application::OIDC_API_REQ_HEADER);
+		$headerToken = preg_replace('/^bearer\s+/i', '', $headerToken);
+		if ($headerToken === '') {
+			$this->logger->error('No Bearer token');
+			error_log('No Bearer token');
+			return '';
+		}
+
+		// try to decode the bearer token
+		JWT::$leeway = 60;
+		$payload = null;
+		try {
+			$payload = JWT::decode($headerToken, $jwks, array_keys(JWT::$supported_algs));
+		} catch (\Exception | \Throwable $e) {
+			$this->logger->error('Impossible to decode OIDC token');
+			error_log('Impossible to decode OIDC token');
+		}
+
+		// successfully decoded
+		if (!is_null($payload)) {
+			// $prettyToken = json_encode($payload, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+
+			// check if the token has expired
+			if ($payload->exp < $this->timeFactory->getTime()) {
+				$this->logger->error('OIDC token has expired');
+				error_log('OIDC token has expired');
+				return '';
+			}
+
+			// find the user ID
+			if (isset($payload->{$uidAttribute})) {
+				$userId = $payload->{$uidAttribute};
+				error_log('user ID found in decoded token: ' . $userId);
+			} else {
+				// this might be an access token
+				error_log('DECODED token: userId not found, NO $payload->{' . $uidAttribute . '}');
+			}
+		} else {
+			error_log('impossible to decode the token');
+		}
+
+		// if user ID was not found in decoded token OR token couldn't be decoded
+		// the token might be an access token, try userinfo
+		if (is_null($userId)) {
+			$userInfo = $this->getUserinfo($headerToken, $discovery['userinfo_endpoint'], $client);
+			$userId = $userInfo[$uidAttribute] ?? null;
+			error_log('user ID in userinfo: ' . $userId);
+		}
+
+		if (is_null($userId)) {
+			$this->logger->error('No user ID found');
+			error_log('No user ID found');
+			return '';
+		}
+
+		$backendUser = $this->userMapper->getOrCreate($provider->getId(), $userId);
+		return $backendUser->getUserId();
+	}
+
+	private function getUserinfo(string $accessToken, string $userinfoUrl, IClient $client): array {
+		$options = [
+			'headers' => [
+				'Authorization' => 'Bearer ' . $accessToken,
+			],
+		];
+		try {
+			return json_decode($client->get($userinfoUrl, $options)->getBody(), true);
+		} catch (\Exception | \Throwable $e) {
+			return [];
+		}
+	}
+
+	private function obtainDiscovery(string $url) {
+		$client = $this->clientService->newClient();
+
+		$this->logger->debug('Obtaining discovery endpoint: ' . $url);
+		$response = $client->get($url);
+
+		$body = json_decode($response->getBody(), true);
+		return $body;
 	}
 }

--- a/lib/User/Backend.php
+++ b/lib/User/Backend.php
@@ -25,72 +25,43 @@ declare(strict_types=1);
 
 namespace OCA\UserOIDC\User;
 
+use OCA\UserOIDC\User\Validator\SelfEncodedValidator;
+use OCA\UserOIDC\User\Validator\UserInfoValidator;
 use OCA\UserOIDC\AppInfo\Application;
 use OCA\UserOIDC\Db\ProviderMapper;
 use OCA\UserOIDC\Db\UserMapper;
-use OCA\UserOIDC\Service\ProviderService;
-use OCA\UserOIDC\Vendor\Firebase\JWT\JWK;
-use OCA\UserOIDC\Vendor\Firebase\JWT\JWT;
 use OCP\AppFramework\Db\DoesNotExistException;
-use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\Authentication\IApacheBackend;
 use OCP\DB\Exception;
-use OCP\Http\Client\IClient;
-use OCP\Http\Client\IClientService;
 use OCP\IRequest;
-use OCP\ISession;
 use OCP\User\Backend\ABackend;
 use OCP\User\Backend\IGetDisplayNameBackend;
 use OCP\User\Backend\IPasswordConfirmationBackend;
 use Psr\Log\LoggerInterface;
 
 class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisplayNameBackend, IApacheBackend {
+	private $tokenValidators = [
+		SelfEncodedValidator::class,
+		UserInfoValidator::class,
+	];
 
 	/** @var UserMapper */
 	private $userMapper;
 	/** @var LoggerInterface */
 	private $logger;
-	/**
-	 * @var ISession
-	 */
-	private $session;
-	/**
-	 * @var IRequest
-	 */
+	/** @var IRequest */
 	private $request;
-	/**
-	 * @var IClientService
-	 */
-	private $clientService;
-	/**
-	 * @var ProviderMapper
-	 */
+	/** @var ProviderMapper */
 	private $providerMapper;
-	/**
-	 * @var ITimeFactory
-	 */
-	private $timeFactory;
-	/**
-	 * @var ProviderService
-	 */
-	private $providerService;
 
 	public function __construct(UserMapper $userMapper,
 								LoggerInterface $logger,
-								ISession $session,
 								IRequest $request,
-								ITimeFactory $timeFactory,
-								IClientService $clientService,
-								ProviderService $providerService,
 								ProviderMapper $providerMapper) {
 		$this->userMapper = $userMapper;
 		$this->logger = $logger;
-		$this->session = $session;
 		$this->request = $request;
-		$this->clientService = $clientService;
 		$this->providerMapper = $providerMapper;
-		$this->timeFactory = $timeFactory;
-		$this->providerService = $providerService;
 	}
 
 	public function getBackendName(): string {
@@ -148,6 +119,7 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 	 */
 	public function isSessionActive() {
 		// if this returns true, getCurrentUserId is called
+		// not sure if we should rather to the validation in here as otherwise it might fail for other backends or bave other side effects
 		$headerToken = $this->request->getHeader(Application::OIDC_API_REQ_HEADER);
 		return $headerToken !== '';
 	}
@@ -175,109 +147,29 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 			return '';
 		}
 
-		// get attribute mapping settings
-		$uidAttribute = $this->providerService->getSetting($provider->getId(), ProviderService::SETTING_MAPPING_UID, 'sub');
-		$userId = null;
-
-		/*
-		 * try to decode the token
-		 * if valid:
-		 * 		if not expired and we find user ID mapping attr inside:
-		 * 			validate
-		 * 		else:
-		 * 			it might be an access token, try to use it to reach userinfo
-		 * else:
-		 * 		it might be an access token, try to use it to reach userinfo
-		 */
-
-		// get the JWKS from the provider
-		$discovery = $this->obtainDiscovery($provider->getDiscoveryEndpoint());
-		$client = $this->clientService->newClient();
-		$result = json_decode($client->get($discovery['jwks_uri'])->getBody(), true);
-		$this->logger->debug('Obtained the jwks');
-		$jwks = JWK::parseKeySet($result);
-		$this->logger->debug('Parsed the jwks');
-
 		// get the bearer token from headers
 		$headerToken = $this->request->getHeader(Application::OIDC_API_REQ_HEADER);
 		$headerToken = preg_replace('/^bearer\s+/i', '', $headerToken);
 		if ($headerToken === '') {
 			$this->logger->error('No Bearer token');
-			error_log('No Bearer token');
 			return '';
 		}
 
-		// try to decode the bearer token
-		JWT::$leeway = 60;
-		$payload = null;
-		try {
-			$payload = JWT::decode($headerToken, $jwks, array_keys(JWT::$supported_algs));
-		} catch (\Exception | \Throwable $e) {
-			$this->logger->error('Impossible to decode OIDC token');
-			error_log('Impossible to decode OIDC token');
-		}
-
-		// successfully decoded
-		if (!is_null($payload)) {
-			// $prettyToken = json_encode($payload, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
-
-			// check if the token has expired
-			if ($payload->exp < $this->timeFactory->getTime()) {
-				$this->logger->error('OIDC token has expired');
-				error_log('OIDC token has expired');
-				return '';
+		$userId = null;
+		// find user id through different token validation methods
+		foreach ($this->tokenValidators as $validatorClass) {
+			$validator = \OC::$server->get($validatorClass);
+			$userId = $validator->isValidBearerToken($provider, $headerToken);
+			if ($userId) {
+				break;
 			}
-
-			// find the user ID
-			if (isset($payload->{$uidAttribute})) {
-				$userId = $payload->{$uidAttribute};
-				error_log('user ID found in decoded token: ' . $userId);
-			} else {
-				// this might be an access token
-				error_log('DECODED token: userId not found, NO $payload->{' . $uidAttribute . '}');
-			}
-		} else {
-			error_log('impossible to decode the token');
 		}
 
-		// if user ID was not found in decoded token OR token couldn't be decoded
-		// the token might be an access token, try userinfo
-		if (is_null($userId)) {
-			$userInfo = $this->getUserinfo($headerToken, $discovery['userinfo_endpoint'], $client);
-			$userId = $userInfo[$uidAttribute] ?? null;
-			error_log('user ID in userinfo: ' . $userId);
-		}
-
-		if (is_null($userId)) {
-			$this->logger->error('No user ID found');
-			error_log('No user ID found');
+		if ($userId === null) {
+			$this->logger->error('Could not find unique token validation');
 			return '';
 		}
-
 		$backendUser = $this->userMapper->getOrCreate($provider->getId(), $userId);
 		return $backendUser->getUserId();
-	}
-
-	private function getUserinfo(string $accessToken, string $userinfoUrl, IClient $client): array {
-		$options = [
-			'headers' => [
-				'Authorization' => 'Bearer ' . $accessToken,
-			],
-		];
-		try {
-			return json_decode($client->get($userinfoUrl, $options)->getBody(), true);
-		} catch (\Exception | \Throwable $e) {
-			return [];
-		}
-	}
-
-	private function obtainDiscovery(string $url) {
-		$client = $this->clientService->newClient();
-
-		$this->logger->debug('Obtaining discovery endpoint: ' . $url);
-		$response = $client->get($url);
-
-		$body = json_decode($response->getBody(), true);
-		return $body;
 	}
 }

--- a/lib/User/Validator/IBearerTokenValidator.php
+++ b/lib/User/Validator/IBearerTokenValidator.php
@@ -23,38 +23,18 @@
 
 declare(strict_types=1);
 
-namespace OCA\UserOIDC\Event;
+namespace OCA\UserOIDC\User\Validator;
 
 use OCA\UserOIDC\Db\Provider;
-use OCP\EventDispatcher\Event;
 
-/**
- * This event is emitted with the raw token information that is returned to the code endpoint
- *
- * It may be used for further handling of oidc authenticated requests
- */
-class TokenObtainedEvent extends Event {
-	private $token;
-	private $provider;
-	private $discovery;
+interface IBearerTokenValidator {
 
-	public function __construct(array $token, $provider, $discovery) {
-		parent::__construct();
-
-		$this->token = $token;
-		$this->provider = $provider;
-		$this->discovery = $discovery;
-	}
-
-	public function getToken(): array {
-		return $this->token;
-	}
-
-	public function getProvider(): Provider {
-		return $this->provider;
-	}
-
-	public function getDiscovery(): array {
-		return $this->discovery;
-	}
+	/**
+	 * Validate the passed token and return the matched user id if found
+	 *
+	 * @param Provider $provider
+	 * @param string $bearerToken
+	 * @return string|null user id or null if the token was not valid
+	 */
+	public function isValidBearerToken(Provider $provider, string $bearerToken): ?string;
 }

--- a/lib/User/Validator/SelfEncodedValidator.php
+++ b/lib/User/Validator/SelfEncodedValidator.php
@@ -1,0 +1,78 @@
+<?php
+/*
+ * @copyright Copyright (c) 2021 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+namespace OCA\UserOIDC\User\Validator;
+
+use OCA\UserOIDC\Db\Provider;
+use OCA\UserOIDC\Service\DiscoveryService;
+use OCA\UserOIDC\Service\ProviderService;
+use OCA\UserOIDC\Vendor\Firebase\JWT\JWT;
+use OCP\AppFramework\Utility\ITimeFactory;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+class SelfEncodedValidator implements IBearerTokenValidator {
+
+	/** @var DiscoveryService */
+	private $discoveryService;
+	/** @var LoggerInterface */
+	private $logger;
+	/** @var ITimeFactory */
+	private $timeFactory;
+
+	public function __construct(DiscoveryService $discoveryService, LoggerInterface $logger, ITimeFactory $timeFactory) {
+		$this->discoveryService = $discoveryService;
+		$this->logger = $logger;
+		$this->timeFactory = $timeFactory;
+	}
+
+	public function isValidBearerToken(Provider $provider, string $bearerToken): ?string {
+		/** @var ProviderService $providerService */
+		$providerService = \OC::$server->get(ProviderService::class);
+		$uidAttribute = $providerService->getSetting($provider->getId(), ProviderService::SETTING_MAPPING_UID, ProviderService::SETTING_MAPPING_UID_DEFAULT);
+
+		// try to decode the bearer token
+		JWT::$leeway = 60;
+		try {
+			$payload = JWT::decode($bearerToken, $this->discoveryService->obtainJWK($provider), array_keys(JWT::$supported_algs));
+		} catch (Throwable $e) {
+			$this->logger->error('Impossible to decode OIDC token:' . $e->getMessage());
+			return null;
+		}
+
+		// check if the token has expired
+		if ($payload->exp < $this->timeFactory->getTime()) {
+			$this->logger->error('OIDC token has expired');
+			return null;
+		}
+
+		// find the user ID
+		if (!isset($payload->{$uidAttribute})) {
+			return null;
+		}
+
+		return $payload->{$uidAttribute};
+	}
+}

--- a/lib/User/Validator/UserInfoValidator.php
+++ b/lib/User/Validator/UserInfoValidator.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * @copyright Copyright (c) 2021 Julius Härtl <jus@bitgrid.net>
+ *
+ * @author Julius Härtl <jus@bitgrid.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+namespace OCA\UserOIDC\User\Validator;
+
+use OCA\UserOIDC\Db\Provider;
+use OCA\UserOIDC\Service\DiscoveryService;
+use OCA\UserOIDC\Service\ProviderService;
+use OCA\UserOIDC\Service\OIDCService;
+use Psr\Log\LoggerInterface;
+
+class UserInfoValidator implements IBearerTokenValidator {
+
+	/** @var DiscoveryService */
+	private $discoveryService;
+	/** @var OIDCService */
+	private $userInfoService;
+	/** @var ProviderService */
+	private $providerService;
+	/** @var LoggerInterface */
+	private $logger;
+
+
+	public function __construct(DiscoveryService $discoveryService, LoggerInterface $logger, OIDCService $userInfoService, ProviderService $providerService) {
+		$this->discoveryService = $discoveryService;
+		$this->logger = $logger;
+		$this->userInfoService = $userInfoService;
+		$this->providerService = $providerService;
+	}
+
+	public function isValidBearerToken(Provider $provider, string $bearerToken): ?string {
+		$userInfo = $this->userInfoService->userinfo($provider, $bearerToken);
+		$uidAttribute = $this->providerService->getSetting($provider->getId(), ProviderService::SETTING_MAPPING_UID, ProviderService::SETTING_MAPPING_UID_DEFAULT);
+		if (!isset($userInfo[$uidAttribute])) {
+			return null;
+		}
+
+		return $userInfo[$uidAttribute];
+	}
+}

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -141,6 +141,7 @@ export default {
 				discoveryEndpoint: '',
 				settings: {
 					uniqueUid: true,
+					checkBearer: false,
 				},
 			},
 			showNewProvider: false,

--- a/src/components/SettingsForm.vue
+++ b/src/components/SettingsForm.vue
@@ -95,6 +95,12 @@
 		<p class="settings-hint">
 			{{ t('user_oidc', 'By default every user will get a unique userid that is a hashed value of the provider and user id. This can be turned off but uniqueness of users accross multiple user backends and providers is no longer preserved then.') }}
 		</p>
+		<CheckboxRadioSwitch :checked.sync="localProvider.settings.checkBearer" wrapper-element="div">
+			{{ t('user_oidc', 'Check Bearer token on API and WebDav requests') }}
+		</CheckboxRadioSwitch>
+		<p class="settings-hint">
+			{{ t('user_oidc', 'Do you want to allow API calls and WebDav request that are authenticated with an OIDC ID token or access token?') }}
+		</p>
 		<input type="button" :value="t('user_oidc', 'Cancel')" @click="$emit('cancel')">
 		<input type="submit" :value="submitText">
 	</form>

--- a/tests/unit/Service/ProviderServiceTest.php
+++ b/tests/unit/Service/ProviderServiceTest.php
@@ -81,6 +81,7 @@ class ProviderServiceTest extends TestCase {
 					'mappingQuota' => '1',
 					'mappingUid' => '1',
 					'uniqueUid' => true,
+					'checkBearer' => true,
 				],
 			],
 			[
@@ -95,6 +96,7 @@ class ProviderServiceTest extends TestCase {
 					'mappingQuota' => '1',
 					'mappingUid' => '1',
 					'uniqueUid' => true,
+					'checkBearer' => true,
 				],
 			],
 		], $this->providerService->getProvidersWithSettings());
@@ -106,7 +108,8 @@ class ProviderServiceTest extends TestCase {
 			'mappingEmail' => 'mail',
 			'mappingQuota' => '1g',
 			'mappingUid' => 'uid',
-			'uniqueUid' => '1',
+			'uniqueUid' => true,
+			'checkBearer' => false,
 		];
 		$this->config->expects(self::any())
 			->method('getAppValue')
@@ -116,6 +119,7 @@ class ProviderServiceTest extends TestCase {
 				[Application::APP_ID, 'provider-1-' . ProviderService::SETTING_MAPPING_QUOTA, '', '1g'],
 				[Application::APP_ID, 'provider-1-' . ProviderService::SETTING_MAPPING_UID, '', 'uid'],
 				[Application::APP_ID, 'provider-1-' . ProviderService::SETTING_UNIQUE_UID, '', '1'],
+				[Application::APP_ID, 'provider-1-' . ProviderService::SETTING_CHECK_BEARER, '', '0'],
 			]);
 
 		Assert::assertEquals(
@@ -126,6 +130,11 @@ class ProviderServiceTest extends TestCase {
 		Assert::assertEquals(
 			array_merge($defaults, ['uniqueUid' => '0']),
 			$this->providerService->setSettings(1, [ProviderService::SETTING_UNIQUE_UID => '0'])
+		);
+
+		Assert::assertEquals(
+			array_merge($defaults, ['checkBearer' => '1']),
+			$this->providerService->setSettings(1, [ProviderService::SETTING_CHECK_BEARER => '1'])
 		);
 	}
 
@@ -171,6 +180,10 @@ class ProviderServiceTest extends TestCase {
 			[ProviderService::SETTING_UNIQUE_UID, true, '1', true],
 			[ProviderService::SETTING_UNIQUE_UID, false, '0', false],
 			[ProviderService::SETTING_UNIQUE_UID, 'test', '1', true],
+			// Setting check bearer is a boolean
+			[ProviderService::SETTING_CHECK_BEARER, true, '1', true],
+			[ProviderService::SETTING_CHECK_BEARER, false, '0', false],
+			[ProviderService::SETTING_CHECK_BEARER, 'test', '1', true],
 			// Any other values are just strings
 			[ProviderService::SETTING_MAPPING_EMAIL, false, '', false],
 			[ProviderService::SETTING_MAPPING_EMAIL, true, '1', true],


### PR DESCRIPTION
Based on https://github.com/nextcloud/user_oidc/pull/317

- Move bearer token validation to separate classes
  - Self-contained access token (JWT)
  - UserInfo based validation
  - Possible for later: using token introspection endpoint
- Move some OpenID connect API calls to a dedicated service

## TODO

- [x] Make bearer token check optional as it has performance impact and maybe not be used on all setups (done in #321)