### PR TITLE
make bearer check in API/WebDav calls optional

### DIFF
--- a/lib/Command/UpsertProvider.php
+++ b/lib/Command/UpsertProvider.php
@@ -58,6 +58,7 @@ class UpsertProvider extends Command {
 
 			->addOption('scope', 'o', InputOption::VALUE_OPTIONAL, 'OpenID requested value scopes, if not set defaults to "openid email profile"')
 			->addOption('unique-uid', null, InputOption::VALUE_OPTIONAL, 'Flag if unique user ids shall be used or not. 1 to enable (default), 0 to disable.')
+			->addOption('check-bearer', null, InputOption::VALUE_OPTIONAL, 'Flag if Nextcloud API/WebDav calls should check the Bearer token against this provider or not. 1 to enable (default), 0 to disable.')
 			->addOption('mapping-display-name', null, InputOption::VALUE_OPTIONAL, 'Attribute mapping of the display name')
 			->addOption('mapping-email', null, InputOption::VALUE_OPTIONAL, 'Attribute mapping of the email address')
 			->addOption('mapping-quota', null, InputOption::VALUE_OPTIONAL, 'Attribute mapping of the quota')
@@ -90,7 +91,7 @@ class UpsertProvider extends Command {
 		$updateOptions = array_filter($input->getOptions(), static function ($value, $option) {
 			return in_array($option, [
 				'identifier', 'clientid', 'clientsecret', 'discoveryuri',
-				'scope', 'unique-uid',
+				'scope', 'unique-uid', 'check-bearer',
 				'mapping-uid', 'mapping-display-name', 'mapping-email', 'mapping-quota',
 			]) && $value !== null;
 		}, ARRAY_FILTER_USE_BOTH);
@@ -129,6 +130,9 @@ class UpsertProvider extends Command {
 		} catch (DoesNotExistException | MultipleObjectsReturnedException $e) {
 			$output->writeln('<error>' . $e->getMessage() . '</error>');
 			return -1;
+		}
+		if (($checkBearer = $input->getOption('check-bearer')) !== null) {
+			$this->providerService->setSetting($provider->getId(), ProviderService::SETTING_CHECK_BEARER, (string)$checkBearer === '0' ? '0' : '1');
 		}
 		if (($uniqueUid = $input->getOption('unique-uid')) !== null) {
 			$this->providerService->setSetting($provider->getId(), ProviderService::SETTING_UNIQUE_UID, (string)$uniqueUid === '0' ? '0' : '1');

--- a/lib/Service/ProviderService.php
+++ b/lib/Service/ProviderService.php
@@ -33,6 +33,7 @@ use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\IConfig;
 
 class ProviderService {
+	public const SETTING_CHECK_BEARER = 'checkBearer';
 	public const SETTING_UNIQUE_UID = 'uniqueUid';
 	public const SETTING_MAPPING_UID = 'mappingUid';
 	public const SETTING_MAPPING_UID_DEFAULT = 'sub';
@@ -121,19 +122,21 @@ class ProviderService {
 			self::SETTING_MAPPING_EMAIL,
 			self::SETTING_MAPPING_QUOTA,
 			self::SETTING_MAPPING_UID,
-			self::SETTING_UNIQUE_UID
+			self::SETTING_UNIQUE_UID,
+			self::SETTING_CHECK_BEARER,
 		];
 	}
 
 	private function convertFromJSON(string $key, $value): string {
-		if ($key === self::SETTING_UNIQUE_UID) {
+		if ($key === self::SETTING_UNIQUE_UID || $key === self::SETTING_CHECK_BEARER) {
 			$value = $value ? '1' : '0';
 		}
 		return (string)$value;
 	}
 
 	private function convertToJSON(string $key, $value) {
-		if ($key === self::SETTING_UNIQUE_UID) {
+		// default is disabled (if not set)
+		if ($key === self::SETTING_UNIQUE_UID || $key === self::SETTING_CHECK_BEARER) {
 			return $value === '1';
 		}
 		return (string)$value;

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -141,6 +141,7 @@ export default {
 				discoveryEndpoint: '',
 				settings: {
 					uniqueUid: true,
+					checkBearer: false,
 				},
 			},
 			showNewProvider: false,

--- a/src/components/SettingsForm.vue
+++ b/src/components/SettingsForm.vue
@@ -95,6 +95,12 @@
 		<p class="settings-hint">
 			{{ t('user_oidc', 'By default every user will get a unique userid that is a hashed value of the provider and user id. This can be turned off but uniqueness of users accross multiple user backends and providers is no longer preserved then.') }}
 		</p>
+		<CheckboxRadioSwitch :checked.sync="localProvider.settings.checkBearer" wrapper-element="div">
+			{{ t('user_oidc', 'Check Bearer token on API and WebDav requests') }}
+		</CheckboxRadioSwitch>
+		<p class="settings-hint">
+			{{ t('user_oidc', 'Do you want to allow API calls and WebDav request that are authenticated with an OIDC ID token or access token?') }}
+		</p>
 		<input type="button" :value="t('user_oidc', 'Cancel')" @click="$emit('cancel')">
 		<input type="submit" :value="submitText">
 	</form>

--- a/tests/unit/Service/ProviderServiceTest.php
+++ b/tests/unit/Service/ProviderServiceTest.php
@@ -81,6 +81,7 @@ class ProviderServiceTest extends TestCase {
 					'mappingQuota' => '1',
 					'mappingUid' => '1',
 					'uniqueUid' => true,
+					'checkBearer' => true,
 				],
 			],
 			[
@@ -95,6 +96,7 @@ class ProviderServiceTest extends TestCase {
 					'mappingQuota' => '1',
 					'mappingUid' => '1',
 					'uniqueUid' => true,
+					'checkBearer' => true,
 				],
 			],
 		], $this->providerService->getProvidersWithSettings());
@@ -106,7 +108,8 @@ class ProviderServiceTest extends TestCase {
 			'mappingEmail' => 'mail',
 			'mappingQuota' => '1g',
 			'mappingUid' => 'uid',
-			'uniqueUid' => '1',
+			'uniqueUid' => true,
+			'checkBearer' => false,
 		];
 		$this->config->expects(self::any())
 			->method('getAppValue')
@@ -116,6 +119,7 @@ class ProviderServiceTest extends TestCase {
 				[Application::APP_ID, 'provider-1-' . ProviderService::SETTING_MAPPING_QUOTA, '', '1g'],
 				[Application::APP_ID, 'provider-1-' . ProviderService::SETTING_MAPPING_UID, '', 'uid'],
 				[Application::APP_ID, 'provider-1-' . ProviderService::SETTING_UNIQUE_UID, '', '1'],
+				[Application::APP_ID, 'provider-1-' . ProviderService::SETTING_CHECK_BEARER, '', '0'],
 			]);
 
 		Assert::assertEquals(
@@ -126,6 +130,11 @@ class ProviderServiceTest extends TestCase {
 		Assert::assertEquals(
 			array_merge($defaults, ['uniqueUid' => '0']),
 			$this->providerService->setSettings(1, [ProviderService::SETTING_UNIQUE_UID => '0'])
+		);
+
+		Assert::assertEquals(
+			array_merge($defaults, ['checkBearer' => '1']),
+			$this->providerService->setSettings(1, [ProviderService::SETTING_CHECK_BEARER => '1'])
 		);
 	}
 
@@ -171,6 +180,10 @@ class ProviderServiceTest extends TestCase {
 			[ProviderService::SETTING_UNIQUE_UID, true, '1', true],
 			[ProviderService::SETTING_UNIQUE_UID, false, '0', false],
 			[ProviderService::SETTING_UNIQUE_UID, 'test', '1', true],
+			// Setting check bearer is a boolean
+			[ProviderService::SETTING_CHECK_BEARER, true, '1', true],
+			[ProviderService::SETTING_CHECK_BEARER, false, '0', false],
+			[ProviderService::SETTING_CHECK_BEARER, 'test', '1', true],
 			// Any other values are just strings
 			[ProviderService::SETTING_MAPPING_EMAIL, false, '', false],
 			[ProviderService::SETTING_MAPPING_EMAIL, true, '1', true],


### PR DESCRIPTION
This adds (in #320) an option to toggle Bearer token check for each provider. This new option is used in the user backend.

For now, this option value is stored the "old fashioned" way: in `oc_appconfig` instead of the `oc_user_oidc_providers` table (like it's been recently done for `scope`).
Would you prefer to store it in `oc_user_oidc_providers`?

It's been successfully tested on my test environment.

I'll make a review of #320 once this is merged (or not :grin:).