### PR TITLE
Remove redundant and time consuming userinfo validation

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -304,21 +304,6 @@ class LoginController extends Controller {
 		$email = $payload->{$emailAttribute} ?? null;
 		$quota = $payload->{$quotaAttribute} ?? null;
 
-		// if something is missing from the token, get user info from /userinfo endpoint
-		// FIXME: only when attribute mapping is set or optional
-		if (is_null($userId) || is_null($userName) || is_null($email) || is_null($quota)) {
-			$options = [
-				'headers' => [
-					'Authorization' => 'Bearer ' . $data['access_token'],
-				],
-			];
-			$userInfoResult = json_decode($client->get($discovery['userinfo_endpoint'], $options)->getBody(), true);
-			$userId = $userId ?? $userInfoResult[$uidAttribute] ?? null;
-			$userName = $userName ?? $userInfoResult[$displaynameAttribute] ?? null;
-			$email = $email ?? $userInfoResult[$emailAttribute] ?? null;
-			$quota = $quota ?? $userInfoResult[$quotaAttribute] ?? null;
-		}
-
 		$event = new AttributeMappedEvent(ProviderService::SETTING_MAPPING_UID, $payload, $userId);
 		$this->eventDispatcher->dispatchTyped($event);
 		if (!$event->hasValue()) {

--- a/lib/User/Backend.php
+++ b/lib/User/Backend.php
@@ -27,7 +27,6 @@ namespace OCA\UserOIDC\User;
 
 use OCA\UserOIDC\Service\ProviderService;
 use OCA\UserOIDC\User\Validator\SelfEncodedValidator;
-use OCA\UserOIDC\User\Validator\UserInfoValidator;
 use OCA\UserOIDC\AppInfo\Application;
 use OCA\UserOIDC\Db\ProviderMapper;
 use OCA\UserOIDC\Db\UserMapper;
@@ -43,7 +42,6 @@ use Psr\Log\LoggerInterface;
 class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisplayNameBackend, IApacheBackend {
 	private $tokenValidators = [
 		SelfEncodedValidator::class,
-		UserInfoValidator::class,
 	];
 
 	/** @var UserMapper */


### PR DESCRIPTION
As we claim the required attributes, they will be included in the token itself. If they are not, they won't be included in `userinfo` response neither.

Let's keep the related validator though.