### PR TITLE
Cache provider public keys

### DIFF
--- a/lib/Command/UpsertProvider.php
+++ b/lib/Command/UpsertProvider.php
@@ -127,6 +127,9 @@ class UpsertProvider extends Command {
 		$scope = $scope ?? 'openid email profile';
 		try {
 			$provider = $this->providerMapper->createOrUpdateProvider($identifier, $clientid, $clientsecret, $discoveryuri, $scope);
+			// invalidate JWKS cache (even if it was just created)
+			$this->providerService->setSetting($provider->getId(), ProviderService::SETTING_JWKS_CACHE, '');
+			$this->providerService->setSetting($provider->getId(), ProviderService::SETTING_JWKS_CACHE_TIMESTAMP, '');
 		} catch (DoesNotExistException | MultipleObjectsReturnedException $e) {
 			$output->writeln('<error>' . $e->getMessage() . '</error>');
 			return -1;

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -95,6 +95,9 @@ class SettingsController extends Controller {
 		$provider = $this->providerMapper->update($provider);
 
 		$providerSettings = $this->providerService->setSettings($providerId, $settings);
+		// invalidate JWKS cache
+		$this->providerService->setSetting($providerId, ProviderService::SETTING_JWKS_CACHE, '');
+		$this->providerService->setSetting($providerId, ProviderService::SETTING_JWKS_CACHE_TIMESTAMP, '');
 
 		return new JSONResponse(array_merge($provider->jsonSerialize(), ['settings' => $providerSettings]));
 	}

--- a/lib/Service/ProviderService.php
+++ b/lib/Service/ProviderService.php
@@ -40,6 +40,8 @@ class ProviderService {
 	public const SETTING_MAPPING_DISPLAYNAME = 'mappingDisplayName';
 	public const SETTING_MAPPING_EMAIL = 'mappingEmail';
 	public const SETTING_MAPPING_QUOTA = 'mappingQuota';
+	public const SETTING_JWKS_CACHE = 'jwksCache';
+	public const SETTING_JWKS_CACHE_TIMESTAMP = 'jwksCacheTimestamp';
 
 	/** @var IConfig */
 	private $config;


### PR DESCRIPTION
We could cache the jwks. This avoid 2 frequents requests to discovery endpoint and jwks_uri.
I don't know if the keys can change in time. I assume it's very rare. Even then, they will be refreshed when the cache expires.
Is this a good approach to cache such things?