### PR TITLE
New system config to disable SelfEncodedValidator bearer token validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,15 @@ Add this to `config.php` to enable such extra validation step:
 ],
 ```
 
+If you only want the token to be validated against the `userinfo` endpoint,
+it is possible to disable the classic "self-encoded" validation:
+``` php
+'user_oidc' => [
+    'userinfo_bearer_validation' => true,
+    'selfencoded_bearer_validation' => false,
+],
+```
+
 ## Building the app
 
 Requirements for building:

--- a/lib/User/Backend.php
+++ b/lib/User/Backend.php
@@ -165,10 +165,16 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 			return '';
 		}
 
-		// check if we should use UserInfoValidator
 		$oidcSystemConfig = $this->config->getSystemValue('user_oidc', []);
+		// check if we should use UserInfoValidator (default is false)
 		if (!isset($oidcSystemConfig['userinfo_bearer_validation']) || !$oidcSystemConfig['userinfo_bearer_validation']) {
 			if (($key = array_search(UserInfoValidator::class, $this->tokenValidators)) !== false) {
+				unset($this->tokenValidators[$key]);
+			}
+		}
+		// check if we should use SelfEncodedValidator (default is true)
+		if (isset($oidcSystemConfig['selfencoded_bearer_validation']) && !$oidcSystemConfig['selfencoded_bearer_validation']) {
+			if (($key = array_search(SelfEncodedValidator::class, $this->tokenValidators)) !== false) {
 				unset($this->tokenValidators[$key]);
 			}
 		}


### PR DESCRIPTION
It can be useful when a token is invalidated/revoked on the IDP side. The only way to know that is to only use the userinfo endpoint.