### PR TITLE
Add new provider setting to request extra claims

### DIFF
--- a/lib/Command/UpsertProvider.php
+++ b/lib/Command/UpsertProvider.php
@@ -63,6 +63,7 @@ class UpsertProvider extends Command {
 			->addOption('mapping-email', null, InputOption::VALUE_OPTIONAL, 'Attribute mapping of the email address')
 			->addOption('mapping-quota', null, InputOption::VALUE_OPTIONAL, 'Attribute mapping of the quota')
 			->addOption('mapping-uid', null, InputOption::VALUE_OPTIONAL, 'Attribute mapping of the user id')
+			->addOption('extra-claims', null, InputOption::VALUE_OPTIONAL, 'Extra claims to request when getting tokens')
 
 			->addOption(
 				'output',
@@ -93,6 +94,7 @@ class UpsertProvider extends Command {
 				'identifier', 'clientid', 'clientsecret', 'discoveryuri',
 				'scope', 'unique-uid', 'check-bearer',
 				'mapping-uid', 'mapping-display-name', 'mapping-email', 'mapping-quota',
+				'extra-claims'
 			]) && $value !== null;
 		}, ARRAY_FILTER_USE_BOTH);
 
@@ -157,6 +159,9 @@ class UpsertProvider extends Command {
 		}
 		if ($mapping = $input->getOption('mapping-uid')) {
 			$this->providerService->setSetting($provider->getId(), ProviderService::SETTING_MAPPING_UID, $mapping);
+		}
+		if ($extraClaims = $input->getOption('extra-claims')) {
+			$this->providerService->setSetting($provider->getId(), ProviderService::SETTING_EXTRA_CLAIMS, $extraClaims);
 		}
 
 		return 0;

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -187,6 +187,15 @@ class LoginController extends Controller {
 			$claims['userinfo'][$uidAttribute] = ['essential' => true];
 		}
 
+		$extraClaimsString = $this->providerService->getSetting($providerId, ProviderService::SETTING_EXTRA_CLAIMS, '');
+		if ($extraClaimsString) {
+			$extraClaims = explode(' ', $extraClaimsString);
+			foreach ($extraClaims as $extraClaim) {
+				$claims['id_token'][$extraClaim] = null;
+				$claims['userinfo'][$extraClaim] = null;
+			}
+		}
+
 		$data = [
 			'client_id' => $provider->getClientId(),
 			'response_type' => 'code',

--- a/lib/Service/ProviderService.php
+++ b/lib/Service/ProviderService.php
@@ -40,6 +40,7 @@ class ProviderService {
 	public const SETTING_MAPPING_DISPLAYNAME = 'mappingDisplayName';
 	public const SETTING_MAPPING_EMAIL = 'mappingEmail';
 	public const SETTING_MAPPING_QUOTA = 'mappingQuota';
+	public const SETTING_EXTRA_CLAIMS = 'extraClaims';
 	public const SETTING_JWKS_CACHE = 'jwksCache';
 	public const SETTING_JWKS_CACHE_TIMESTAMP = 'jwksCacheTimestamp';
 
@@ -126,6 +127,7 @@ class ProviderService {
 			self::SETTING_MAPPING_UID,
 			self::SETTING_UNIQUE_UID,
 			self::SETTING_CHECK_BEARER,
+			self::SETTING_EXTRA_CLAIMS,
 		];
 	}
 

--- a/src/components/SettingsForm.vue
+++ b/src/components/SettingsForm.vue
@@ -60,6 +60,13 @@
 				type="text"
 				placeholder="openid email profile">
 		</p>
+		<p>
+			<label for="oidc-extra-claims">{{ t('user_oidc', 'Extra claims') }}</label>
+			<input id="oidc-extra-claims"
+				v-model="localProvider.settings.extraClaims"
+				type="text"
+				placeholder="claim1 claim2 claim3">
+		</p>
 		<h4>{{ t('user_oidc', 'Attribute mapping') }}</h4>
 		<p>
 			<label for="mapping-uid">{{ t('user_oidc', 'User ID mapping') }}</label>

--- a/tests/unit/Service/ProviderServiceTest.php
+++ b/tests/unit/Service/ProviderServiceTest.php
@@ -82,6 +82,7 @@ class ProviderServiceTest extends TestCase {
 					'mappingUid' => '1',
 					'uniqueUid' => true,
 					'checkBearer' => true,
+					'extraClaims' => '1',
 				],
 			],
 			[
@@ -97,6 +98,7 @@ class ProviderServiceTest extends TestCase {
 					'mappingUid' => '1',
 					'uniqueUid' => true,
 					'checkBearer' => true,
+					'extraClaims' => '1',
 				],
 			],
 		], $this->providerService->getProvidersWithSettings());
@@ -110,6 +112,7 @@ class ProviderServiceTest extends TestCase {
 			'mappingUid' => 'uid',
 			'uniqueUid' => true,
 			'checkBearer' => false,
+			'extraClaims' => 'claim1 claim2',
 		];
 		$this->config->expects(self::any())
 			->method('getAppValue')
@@ -120,6 +123,7 @@ class ProviderServiceTest extends TestCase {
 				[Application::APP_ID, 'provider-1-' . ProviderService::SETTING_MAPPING_UID, '', 'uid'],
 				[Application::APP_ID, 'provider-1-' . ProviderService::SETTING_UNIQUE_UID, '', '1'],
 				[Application::APP_ID, 'provider-1-' . ProviderService::SETTING_CHECK_BEARER, '', '0'],
+				[Application::APP_ID, 'provider-1-' . ProviderService::SETTING_EXTRA_CLAIMS, '', 'claim1 claim2'],
 			]);
 
 		Assert::assertEquals(
@@ -191,6 +195,7 @@ class ProviderServiceTest extends TestCase {
 			[ProviderService::SETTING_MAPPING_UID, 'test', 'test', 'test'],
 			[ProviderService::SETTING_MAPPING_QUOTA, 'test', 'test', 'test'],
 			[ProviderService::SETTING_MAPPING_DISPLAYNAME, 'test', 'test', 'test'],
+			[ProviderService::SETTING_EXTRA_CLAIMS, 'test', 'test', 'test'],
 		];
 	}
 	/** @dataProvider dataConvertJson */


### PR DESCRIPTION
In case the tokens are used by another app (with the TokenObtainedEvent) it can be useful to have some extra claims to make sure the token (and/or the userinfo result) contains extra attributes.

This adds a field to the provider form. The new setting is stored like the mapping attributes: as an app value.
The upsert command has also been adapted to include this new setting.