### PR TITLE
Ensure that a remember me cookie is created

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -335,6 +335,7 @@ class LoginController extends Controller {
 		$this->userSession->setUser($user);
 		$this->userSession->completeLogin($user, ['loginName' => $user->getUID(), 'password' => '']);
 		$this->userSession->createSessionToken($this->request, $user->getUID(), $user->getUID());
+		$this->userSession->createRememberMeToken($user);
 
 		$this->logger->debug('Redirecting user');
 


### PR DESCRIPTION
Found when debugging a probably unrelated issue about lost authentication while having a browser tab open, but still would be good to have this work the same way as with regular login.

In the core login this is handled in the chain of processing the login:
https://github.com/nextcloud/server/blob/d613b320451516c466fca7b408414a0193139602/core/Controller/LoginController.php#L329
https://github.com/nextcloud/server/blob/215aef3cbdc1963be1bb6bca5218ee0a4b7f1665/lib/private/Authentication/Login/Chain.php#L106
https://github.com/nextcloud/server/blob/215aef3cbdc1963be1bb6bca5218ee0a4b7f1665/lib/private/Authentication/Login/FinishRememberedLoginCommand.php#L46

This can be tested by:
- Login through oidc
- delete all php sessions manually (e.g. `rm /tmp/sess_*`)

Before:
- The user is being logged out

After:
- Additional cookies get set
- The user is still being logged in through the remember me cookie 