### PR TITLE
Ignore more stuff in .nextcloudignore

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -1,10 +1,15 @@
 /AUTHORS.md
 /build
+/.editorconfig
+/.eslintrc.js
 /.git
+/.github
 /.gitignore
+/.php*
 /.travis.yml
 /.tx
 /.scrutinizer.yml
+/babel.config.js
 /CONTRIBUTING.md
 /composer.json
 /composer.lock
@@ -25,6 +30,7 @@
 /vendor/**/tests
 /webpack.common.js
 /webpack.dev.js
+/webpack.js
 /webpack.prod.js
 /vendor/bin
 /vendor-bin


### PR DESCRIPTION
To avoid having useless stuff in the release archive.