### PR TITLE
Fix single logout with non-auto provisioned users

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -47,6 +47,7 @@ class Application extends App implements IBootstrap {
 	public const APP_ID = 'user_oidc';
 	public const OIDC_API_REQ_HEADER = 'Authorization';
 
+	private $backend;
 	private $cachedProviders;
 
 	public function __construct(array $urlParams = []) {
@@ -58,12 +59,13 @@ class Application extends App implements IBootstrap {
 		$userManager = $this->getContainer()->get(IUserManager::class);
 
 		/* Register our own user backend */
-		$backend = $this->getContainer()->get(Backend::class);
-		$userManager->registerBackend($backend);
-		OC_User::useBackend($backend);
+		$this->backend = $this->getContainer()->get(Backend::class);
+		$userManager->registerBackend($this->backend);
+		OC_User::useBackend($this->backend);
 	}
 
 	public function boot(IBootContext $context): void {
+		$context->injectFn(\Closure::fromCallable([$this->backend, 'injectSession']));
 		/** @var IUserSession $userSession */
 		$userSession = $this->getContainer()->get(IUserSession::class);
 		if ($userSession->isLoggedIn()) {

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -431,6 +431,8 @@ class LoginController extends Controller {
 			}
 		}
 		$this->userSession->logout();
+		// make sure we clear the session to avoid messing with Backend::isSessionActive
+		$this->session->clear();
 		return new RedirectResponse($targetUrl);
 	}
 }

--- a/lib/User/Backend.php
+++ b/lib/User/Backend.php
@@ -164,6 +164,16 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 	}
 
 	/**
+	 * As session cannot be injected in the constructor here, we inject it later
+	 *
+	 * @param ISession $session
+	 * @return void
+	 */
+	public function injectSession(ISession $session): void {
+		$this->session = $session;
+	}
+
+	/**
 	 * In case the user has been authenticated by Apache true is returned.
 	 *
 	 * @return boolean whether Apache reports a user as currently logged in.
@@ -174,7 +184,6 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 		// not sure if we should rather to the validation in here as otherwise it might fail for other backends or bave other side effects
 		$headerToken = $this->request->getHeader(Application::OIDC_API_REQ_HEADER);
 		// session is active if we have a bearer token (API request) OR if we logged in via user_oidc (we have a provider ID in the session)
-		// TODO maybe only check the session stuff if a "singleLogout option" is enabled
 		return $headerToken !== '' || $this->session->get(LoginController::PROVIDERID) !== null;
 	}
 


### PR DESCRIPTION
Inject the session in the user backend in `Application::boot` to fix `Backend::isSessionActive` with non-auto provisioned users (which are not considered as user_oidc users).