### PR TITLE
Fix default scope when updating an existing provider with occ

### DIFF
--- a/lib/Command/UpsertProvider.php
+++ b/lib/Command/UpsertProvider.php
@@ -127,11 +127,15 @@ class UpsertProvider extends Command {
 
 		$provider = $this->providerService->getProviderByIdentifier($identifier);
 		if ($provider !== null) {
+			// existing provider, keep values that are not set
 			$clientid = $clientid ?? $provider->getClientId();
 			$clientsecret = $clientsecret ?? $provider->getClientSecret();
 			$discoveryuri = $discoveryuri ?? $provider->getDiscoveryEndpoint();
+			$scope = $scope ?? $provider->getScope();
+		} else {
+			// new provider default scope value
+			$scope = $scope ?? 'openid email profile';
 		}
-		$scope = $scope ?? 'openid email profile';
 		try {
 			$provider = $this->providerMapper->createOrUpdateProvider($identifier, $clientid, $clientsecret, $discoveryuri, $scope);
 			// invalidate JWKS cache (even if it was just created)

--- a/lib/Db/ProviderMapper.php
+++ b/lib/Db/ProviderMapper.php
@@ -86,7 +86,7 @@ class ProviderMapper extends QBMapper {
 	}
 
 	/**
-	 * Create or update provider settinngs
+	 * Create or update provider settings
 	 *
 	 * @param string identifier
 	 * @param string|null $clientid
@@ -108,7 +108,7 @@ class ProviderMapper extends QBMapper {
 		if ($provider === null) {
 			$provider = new Provider();
 			if (($clientid === null) || ($clientsecret === null) || ($discoveryuri === null)) {
-				throw new DoesNotExistException("Provider must be created. All provider parameters required.");
+				throw new DoesNotExistException('Provider must be created. All provider parameters required.');
 			}
 			$provider->setIdentifier($identifier);
 			$provider->setClientId($clientid);


### PR DESCRIPTION
If `--scope` was omitted when updating a provider via `occ user_oidc:provider`, the scope was always set to the default value.
Value is now kept when updating a provider.

Default value is still used when creating a provider.