### PR TITLE
Make sure any delayed avatar generation is triggered

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -337,6 +337,11 @@ class LoginController extends Controller {
 		$this->userSession->createSessionToken($this->request, $user->getUID(), $user->getUID());
 		$this->userSession->createRememberMeToken($user);
 
+		// if the user was provisioned by user_ldap, this is required to update and/or generate the avatar
+		if ($user->canChangeAvatar()) {
+			$this->logger->debug('$user->canChangeAvatar() is true');
+		}
+
 		$this->logger->debug('Redirecting user');
 
 		$redirectUrl = $this->session->get(self::REDIRECT_AFTER_LOGIN);


### PR DESCRIPTION
Another improvement for non-auto provisioning.

Call `$user->canChangeAvatar()` on login to make sure any delayed avatar generation is triggered.
This calls `userBackend->canChangeAvatar($uid)` which may or may not take care of avatar generation. In the `user_ldap` case, it does :grin:.