### PR TITLE
Add admin endpoint to create user for pre-provisioning

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -28,9 +28,13 @@ return [
 		['name' => 'login#login', 'url' => '/login/{providerId}', 'verb' => 'GET'],
 		['name' => 'login#code', 'url' => '/code', 'verb' => 'GET'],
 		['name' => 'login#singleLogoutService', 'url' => '/sls', 'verb' => 'GET'],
+
+		['name' => 'api#createUser', 'url' => '/user', 'verb' => 'POST'],
+
 		['name' => 'id4me#showLogin', 'url' => '/id4me', 'verb' => 'GET'],
 		['name' => 'id4me#login', 'url' => '/id4me', 'verb' => 'POST'],
 		['name' => 'id4me#code', 'url' => '/id4me/code', 'verb' => 'GET'],
+
 		['name' => 'Settings#createProvider', 'url' => '/provider', 'verb' => 'POST'],
 		['name' => 'Settings#updateProvider', 'url' => '/provider/{providerId}', 'verb' => 'PUT'],
 		['name' => 'Settings#deleteProvider', 'url' => '/provider/{providerId}', 'verb' => 'DELETE'],

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022, Julien Veyssier <eneiluj@posteo.net>
+ *
+ * @author Julien Veyssier <eneiluj@posteo.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\UserOIDC\Controller;
+
+use OCA\UserOIDC\AppInfo\Application;
+use OCA\UserOIDC\Db\UserMapper;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\Files\IRootFolder;
+use OCP\Files\NotPermittedException;
+use OCP\IRequest;
+use OCP\IUserManager;
+
+class ApiController extends Controller {
+	/** @var UserMapper */
+	private $userMapper;
+
+	/** @var IUserManager */
+	private $userManager;
+	/**
+	 * @var IRootFolder
+	 */
+	private $root;
+
+	public function __construct(
+		IRequest $request,
+		IRootFolder $root,
+		UserMapper $userMapper,
+		IUserManager $userManager
+	) {
+		parent::__construct(Application::APP_ID, $request);
+		$this->userMapper = $userMapper;
+		$this->userManager = $userManager;
+		$this->root = $root;
+	}
+
+	/**
+	 * @NoCSRFRequired
+	 *
+	 * @param int $providerId
+	 * @param string $userId
+	 * @param string|null $displayName
+	 * @param string|null $email
+	 * @param string|null $quota
+	 * @return DataResponse
+	 */
+	public function createUser(int $providerId, string  $userId, ?string $displayName = null,
+								  ?string $email = null, ?string $quota = null): DataResponse {
+		$backendUser = $this->userMapper->getOrCreate($providerId, $userId);
+		$user = $this->userManager->get($backendUser->getUserId());
+
+		if ($displayName) {
+			if ($displayName !== $backendUser->getDisplayName()) {
+				$backendUser->setDisplayName($displayName);
+				$this->userMapper->update($backendUser);
+			}
+		}
+
+		if ($email) {
+			$user->setEMailAddress($email);
+		}
+
+		if ($quota) {
+			$user->setQuota($quota);
+		}
+
+		$userFolder = $this->root->getUserFolder($userId);
+		try {
+			// copy skeleton
+			\OC_Util::copySkeleton($userId, $userFolder);
+		} catch (NotPermittedException $ex) {
+			// read only uses
+		}
+
+		return new DataResponse(['user_id' => $user->getUID()]);
+	}
+}


### PR DESCRIPTION
In some cases, admins might want to pre-provision users so files can be shared with them before they even logged in once.

A potential solution is to disable auto provision and use user_ldap to provision the users. Problem is then user_oidc looses the ability to update the users attributes because they are then handled by user_ldap.

This small api endpoint allows to pre-create OIDC users (and their storage) just like if they had logged in.