### PR TITLE
Implement backchannel logout

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,17 @@ It can be disabled in `config.php`:
 ],
 ```
 
+### Backchannel logout
+
+[OpenId backchannel logout](https://openid.net/specs/openid-connect-backchannel-1_0.html) is supported by this app.
+You just have to configure 2 settings for the OpenId client (on the provider side, Keycloak for example):
+1. Backchannel Logout URL: If your Nextcloud base URL is https://my.nextcloud.org
+and your OpenId provider identifier (on the Nextcloud side) is "myOidcProvider"
+set the backchannel Logout URL to
+https://my.nextcloud.org/index.php/apps/user_oidc/backchannel-logout/myOidcProvider .
+This URL is provided for each provider in the OpenID Connect admin settings.
+2. Enable the "Backchannel Logout Session Required" setting.
+
 ### Auto provisioning
 
 By default, this app provisions the users with the information contained in the OIDC token

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
 	<name>OpenID Connect user backend</name>
 	<summary>Use an OpenID Connect backend to login to your Nextcloud</summary>
 	<description>Allows flexible configuration of an OIDC server as Nextcloud login user backend.</description>
-	<version>1.2.0</version>
+	<version>1.2.1</version>
 	<licence>agpl</licence>
 	<author>Roeland Jago Douma</author>
 	<author>Julius Härtl</author>
@@ -19,7 +19,7 @@
 	<bugs>https://github.com/nextcloud/user_oidc/issues</bugs>
 	<repository>https://github.com/nextcloud/user_oidc</repository>
 	<dependencies>
-		<nextcloud min-version="20" max-version="25"/>
+		<nextcloud min-version="21" max-version="25"/>
 	</dependencies>
 	<settings>
 		<admin>OCA\UserOIDC\Settings\AdminSettings</admin>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -26,6 +26,9 @@
 		<admin-section>OCA\UserOIDC\Settings\Section</admin-section>
 	</settings>
 
+	<background-jobs>
+		<job>OCA\UserOIDC\Cron\CleanupSessions</job>
+	</background-jobs>
 	<commands>
 		<command>OCA\UserOIDC\Command\UpsertProvider</command>
 		<command>OCA\UserOIDC\Command\DeleteProvider</command>

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -28,6 +28,7 @@ return [
 		['name' => 'login#login', 'url' => '/login/{providerId}', 'verb' => 'GET'],
 		['name' => 'login#code', 'url' => '/code', 'verb' => 'GET'],
 		['name' => 'login#singleLogoutService', 'url' => '/sls', 'verb' => 'GET'],
+		['name' => 'login#backChannelLogout', 'url' => '/backchannel-logout/{providerIdentifier}', 'verb' => 'POST'],
 
 		['name' => 'api#createUser', 'url' => '/user', 'verb' => 'POST'],
 

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -29,6 +29,7 @@ namespace OCA\UserOIDC\Controller;
 
 use OC\Authentication\Exceptions\InvalidTokenException;
 use OC\Authentication\Token\IProvider;
+use OCA\UserOIDC\Db\SessionMapper;
 use OCA\UserOIDC\Event\AttributeMappedEvent;
 use OCA\UserOIDC\Event\TokenObtainedEvent;
 use OCA\UserOIDC\Service\DiscoveryService;
@@ -39,6 +40,8 @@ use OCA\UserOIDC\AppInfo\Application;
 use OCA\UserOIDC\Db\ProviderMapper;
 use OCA\UserOIDC\Db\UserMapper;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\RedirectResponse;
@@ -60,7 +63,6 @@ class LoginController extends Controller {
 	private const NONCE = 'oidc.nonce';
 	public const PROVIDERID = 'oidc.providerid';
 	private const REDIRECT_AFTER_LOGIN = 'oidc.redirect';
-	private const CURRENT_SID = 'oidc.sid';
 
 	/** @var ISecureRandom */
 	private $random;
@@ -112,6 +114,10 @@ class LoginController extends Controller {
 	 * @var IProvider
 	 */
 	private $authTokenProvider;
+	/**
+	 * @var SessionMapper
+	 */
+	private $sessionMapper;
 
 	public function __construct(
 		IRequest $request,
@@ -130,6 +136,7 @@ class LoginController extends Controller {
 		IEventDispatcher $eventDispatcher,
 		IConfig $config,
 		IProvider $authTokenProvider,
+		SessionMapper $sessionMapper,
 		ILogger $logger
 	) {
 		parent::__construct(Application::APP_ID, $request);
@@ -150,6 +157,7 @@ class LoginController extends Controller {
 		$this->config = $config;
 		$this->ldapService = $ldapService;
 		$this->authTokenProvider = $authTokenProvider;
+		$this->sessionMapper = $sessionMapper;
 	}
 
 	/**
@@ -354,8 +362,9 @@ class LoginController extends Controller {
 		$this->userSession->createRememberMeToken($user);
 
 		// for backchannel logout
-		$this->config->setAppValue(Application::APP_ID, 'sid-' . $idTokenPayload->sid, $this->session->getId());
-		$this->session->set(self::CURRENT_SID, $idTokenPayload->sid);
+		$authToken = $this->authTokenProvider->getToken($this->session->getId());
+
+		$this->sessionMapper->createSession($idTokenPayload->sid, $idTokenPayload->sub, $idTokenPayload->iss, $authToken->getId(), $this->session->getId());
 
 		// if the user was provisioned by user_ldap, this is required to update and/or generate the avatar
 		if ($user->canChangeAvatar()) {
@@ -464,9 +473,8 @@ class LoginController extends Controller {
 				$targetUrl .= '?post_logout_redirect_uri=' . $this->urlGenerator->getAbsoluteURL('/');
 			}
 		}
-		// cleanup backchannel logout related config values
-		$sid = $this->session->get(self::CURRENT_SID);
-		$this->config->deleteAppValue(Application::APP_ID, 'sid-' . $sid);
+		// cleanup related oidc session
+		$this->sessionMapper->deleteFromNcSessionId($this->session->getId());
 
 		$this->userSession->logout();
 
@@ -516,23 +524,39 @@ class LoginController extends Controller {
 			return $this->getBackchannelLogoutErrorResponse('invalid nonce', 'The logout token should not contain a nonce attribute');
 		}
 
-		// get the user session ID associated with the logout token's sid attr
+		// get the auth token ID associated with the logout token's sid attr
 		$sid = $logoutTokenPayload->sid;
-		$sessionId = $this->config->getAppValue(Application::APP_ID, 'sid-' . $sid);
-		if ($sessionId === '') {
+		try {
+			$oidcSession = $this->sessionMapper->findSessionBySid($sid);
+		} catch (DoesNotExistException $e) {
 			return $this->getBackchannelLogoutErrorResponse('invalid SID', 'The sid of the logout token was not found');
+		} catch (MultipleObjectsReturnedException $e) {
+			return $this->getBackchannelLogoutErrorResponse('invalid SID', 'The sid of the logout token was found multiple times');
 		}
 
+		$sub = $logoutTokenPayload->sub;
+		if ($oidcSession->getSub() !== $sub) {
+			return $this->getBackchannelLogoutErrorResponse('invalid SUB', 'The sub does not match the one from the login ID token');
+		}
+		$iss = $logoutTokenPayload->iss;
+		if ($oidcSession->getIss() !== $iss) {
+			return $this->getBackchannelLogoutErrorResponse('invalid ISS', 'The iss does not match the one from the login ID token');
+		}
+
+		// i don't know why but the cast is necessary
+		$authTokenId = (int)$oidcSession->getAuthtokenId();
 		try {
-			$sessionToken = $this->authTokenProvider->getToken($sessionId);
-			$userId = $sessionToken->getUID();
-			$this->authTokenProvider->invalidateTokenById($userId, $sessionToken->getId());
+			$authToken = $this->authTokenProvider->getTokenById($authTokenId);
+			// we could also get the auth token by nc session ID
+			// $authToken = $this->authTokenProvider->getToken($oidcSession->getNcSessionId());
+			$userId = $authToken->getUID();
+			$this->authTokenProvider->invalidateTokenById($userId, $authToken->getId());
 		} catch (InvalidTokenException $e) {
-			return $this->getBackchannelLogoutErrorResponse('session not found', 'The session was not found in Nextcloud');
+			return $this->getBackchannelLogoutErrorResponse('nc session not found', 'The authentication session was not found in Nextcloud');
 		}
 
 		// cleanup
-		$this->config->deleteAppValue(Application::APP_ID, 'sid-' . $sid);
+		$this->sessionMapper->delete($oidcSession);
 
 		return new JSONResponse([], Http::STATUS_OK);
 	}

--- a/lib/Cron/CleanupSessions.php
+++ b/lib/Cron/CleanupSessions.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @copyright Copyright (c) 2022, Julien Veyssier <eneiluj@posteo.net>
+ *
+ * @author Julien Veyssier <eneiluj@posteo.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\UserOIDC\Cron;
+
+use DateTime;
+use OCA\UserOIDC\Db\SessionMapper;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\TimedJob;
+use OCP\IConfig;
+
+class CleanupSessions extends TimedJob {
+
+	/**
+	 * @var SessionMapper
+	 */
+	private $sessionMapper;
+	/**
+	 * @var IConfig
+	 */
+	private $config;
+
+	public function __construct(ITimeFactory  $time,
+								IConfig $config,
+								SessionMapper $sessionMapper) {
+		parent::__construct($time);
+		$this->sessionMapper = $sessionMapper;
+		// daily
+		$this->setInterval(24 * 60 * 60);
+		$this->config = $config;
+	}
+
+	/**
+	 * @param $argument
+	 * @return void
+	 */
+	protected function run($argument): void {
+		$nowTimestamp = (new DateTime())->getTimestamp();
+		$configSessionLifetime = $this->config->getSystemValueInt('session_lifetime', 60 * 60 * 24);
+		$configCookieLifetime = $this->config->getSystemValueInt('remember_login_cookie_lifetime', 60 * 60 * 24 * 15);
+		$since = $nowTimestamp - max($configSessionLifetime, $configCookieLifetime);
+		$this->sessionMapper->cleanupSessions($since);
+	}
+}

--- a/lib/Cron/CleanupSessions.php
+++ b/lib/Cron/CleanupSessions.php
@@ -49,7 +49,9 @@ class CleanupSessions extends TimedJob {
 		$this->config = $config;
 		// daily
 		$this->setInterval(24 * 60 * 60);
-		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
+		if (method_exists($this, 'setTimeSensitivity')) {
+			$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
+		}
 	}
 
 	/**

--- a/lib/Cron/CleanupSessions.php
+++ b/lib/Cron/CleanupSessions.php
@@ -26,6 +26,7 @@ namespace OCA\UserOIDC\Cron;
 use DateTime;
 use OCA\UserOIDC\Db\SessionMapper;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\BackgroundJob\IJob;
 use OCP\BackgroundJob\TimedJob;
 use OCP\IConfig;
 
@@ -45,9 +46,10 @@ class CleanupSessions extends TimedJob {
 								SessionMapper $sessionMapper) {
 		parent::__construct($time);
 		$this->sessionMapper = $sessionMapper;
+		$this->config = $config;
 		// daily
 		$this->setInterval(24 * 60 * 60);
-		$this->config = $config;
+		$this->setTimeSensitivity(IJob::TIME_INSENSITIVE);
 	}
 
 	/**

--- a/lib/Db/Session.php
+++ b/lib/Db/Session.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022, Julien Veyssier <eneiluj@posteo.net>
+ *
+ * @author Julien Veyssier <eneiluj@posteo.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\UserOIDC\Db;
+
+use OCP\AppFramework\Db\Entity;
+
+/**
+ * @method string getSid()
+ * @method void setSid(string $sid)
+ * @method string getSub()
+ * @method void setSub(string $sub)
+ * @method string getIss()
+ * @method void setIss(string $iss)
+ * @method int getAuthtokenId()
+ * @method void setAuthtokenId(int $authtokenId)
+ * @method string getNcSessionId()
+ * @method void setNcSessionId(string $ncSessionId)
+ * @method int getCreatedAt()
+ * @method void setCreatedAt(int $createdAt)
+ */
+class Session extends Entity implements \JsonSerializable {
+
+	/** @var string */
+	protected $sid;
+
+	/** @var string */
+	protected $sub;
+
+	/** @var string */
+	protected $iss;
+
+	/** @var int */
+	protected $authtokenId;
+
+	/** @var string */
+	protected $ncSessionId;
+
+	/** @var int */
+	protected $createdAt;
+
+	public function __construct() {
+		$this->addType('sid', 'string');
+		$this->addType('sub', 'string');
+		$this->addType('iss', 'string');
+		$this->addType('authtoken_id', 'integer');
+		$this->addType('nc_session_id', 'string');
+		$this->addType('created_at', 'integer');
+	}
+
+	#[\ReturnTypeWillChange]
+	public function jsonSerialize() {
+		return [
+			'id' => $this->id,
+			'sid' => $this->sid,
+			'sub' => $this->sub,
+			'iss' => $this->iss,
+			'authtoken_id' => $this->authtokenId,
+			'nc_session_id' => $this->ncSessionId,
+			'created_at' => $this->createdAt,
+		];
+	}
+}

--- a/lib/Db/SessionMapper.php
+++ b/lib/Db/SessionMapper.php
@@ -40,11 +40,11 @@ class SessionMapper extends QBMapper {
 
 	/**
 	 * @param int $id
-	 * @return Provider
+	 * @return Session
 	 * @throws \OCP\AppFramework\Db\DoesNotExistException
 	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
 	 */
-	public function getSession(int $id): Provider {
+	public function getSession(int $id): Session {
 		$qb = $this->db->getQueryBuilder();
 
 		$qb->select('*')

--- a/lib/Db/SessionMapper.php
+++ b/lib/Db/SessionMapper.php
@@ -106,18 +106,6 @@ class SessionMapper extends QBMapper {
 	}
 
 	/**
-	 * @return Session[]
-	 */
-	public function getSessions() {
-		$qb = $this->db->getQueryBuilder();
-
-		$qb->select('*')
-			->from($this->getTableName());
-
-		return $this->findEntities($qb);
-	}
-
-	/**
 	 * Create a session
 	 *
 	 * @param string $sid

--- a/lib/Db/SessionMapper.php
+++ b/lib/Db/SessionMapper.php
@@ -92,6 +92,20 @@ class SessionMapper extends QBMapper {
 	}
 
 	/**
+	 * @param int $minCreationTimestamp
+	 * @throws \OCP\DB\Exception
+	 */
+	public function cleanupSessions(int $minCreationTimestamp): void {
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->delete($this->getTableName())
+			->where(
+				$qb->expr()->lt('created_at', $qb->createNamedParameter($minCreationTimestamp, IQueryBuilder::PARAM_INT))
+			);
+		$qb->executeStatement();
+	}
+
+	/**
 	 * @return Session[]
 	 */
 	public function getSessions() {

--- a/lib/Db/SessionMapper.php
+++ b/lib/Db/SessionMapper.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * @copyright Copyright (c) 2022, Julien Veyssier <eneiluj@posteo.net>
+ *
+ * @author Julien Veyssier <eneiluj@posteo.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace OCA\UserOIDC\Db;
+
+use DateTime;
+use OCP\AppFramework\Db\MultipleObjectsReturnedException;
+use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use OCP\IDBConnection;
+
+use OCP\AppFramework\Db\DoesNotExistException;
+
+class SessionMapper extends QBMapper {
+	public function __construct(IDBConnection $db) {
+		parent::__construct($db, 'user_oidc_sessions', Session::class);
+	}
+
+	/**
+	 * @param int $id
+	 * @return Provider
+	 * @throws \OCP\AppFramework\Db\DoesNotExistException
+	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
+	 */
+	public function getSession(int $id): Provider {
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->select('*')
+			->from($this->getTableName())
+			->where(
+				$qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT))
+			);
+
+		return $this->findEntity($qb);
+	}
+
+	/**
+	 * Find session by sid (from the OIDC id token)
+	 *
+	 * @param string $sid
+	 * @return Session
+	 * @throws \OCP\AppFramework\Db\DoesNotExistException
+	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
+	 */
+	public function findSessionBySid(string $sid): Session {
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->select('*')
+			->from($this->getTableName())
+			->where(
+				$qb->expr()->eq('sid', $qb->createNamedParameter($sid, IQueryBuilder::PARAM_STR))
+			);
+
+		return $this->findEntity($qb);
+	}
+
+	/**
+	 * @param string $ncSessionId
+	 * @return int
+	 * @throws \OCP\DB\Exception
+	 */
+	public function deleteFromNcSessionId(string $ncSessionId): int {
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->delete($this->getTableName())
+			->where(
+				$qb->expr()->eq('nc_session_id', $qb->createNamedParameter($ncSessionId, IQueryBuilder::PARAM_STR))
+			);
+		return $qb->executeStatement();
+	}
+
+	/**
+	 * @return Session[]
+	 */
+	public function getSessions() {
+		$qb = $this->db->getQueryBuilder();
+
+		$qb->select('*')
+			->from($this->getTableName());
+
+		return $this->findEntities($qb);
+	}
+
+	/**
+	 * Create a session
+	 *
+	 * @param string $sid
+	 * @param string $sub
+	 * @param string $iss
+	 * @param int $authtokenId
+	 * @param string $ncSessionid
+	 * @return mixed|Session|\OCP\AppFramework\Db\Entity
+	 */
+	public function createSession(string $sid, string $sub, string $iss, int $authtokenId, string $ncSessionid) {
+		try {
+			// do not create if one with same sid already exists (which should not happen)
+			return $this->findSessionBySid($sid);
+		} catch (MultipleObjectsReturnedException $e) {
+			// this can't happen
+			return null;
+		} catch (DoesNotExistException $e) {
+		}
+
+		$createdAt = (new DateTime())->getTimestamp();
+
+		$session = new Session();
+		$session->setSid($sid);
+		$session->setSub($sub);
+		$session->setIss($iss);
+		$session->setAuthtokenId($authtokenId);
+		$session->setNcSessionId($ncSessionid);
+		$session->setCreatedAt($createdAt);
+		return $this->insert($session);
+	}
+}

--- a/lib/Migration/Version01021Date20220719114355.php
+++ b/lib/Migration/Version01021Date20220719114355.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\UserOIDC\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version01021Date20220719114355 extends SimpleMigrationStep {
+
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure The `\Closure` returns a `ISchemaWrapper`
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->createTable('user_oidc_sessions');
+		$table->addColumn('id', Types::INTEGER, [
+			'autoincrement' => true,
+			'notnull' => true,
+			'length' => 4,
+		]);
+		// https://openid.net/specs/openid-connect-core-1_0.html#IDToken
+		$table->addColumn('sid', Types::STRING, [
+			'notnull' => true,
+			'length' => 256,
+		]);
+		$table->addColumn('sub', Types::STRING, [
+			'notnull' => true,
+			'length' => 256,
+		]);
+		$table->addColumn('iss', Types::STRING, [
+			'notnull' => true,
+			'length' => 512,
+		]);
+		$table->addColumn('authtoken_id', Types::INTEGER, [
+			'notnull' => true,
+			'length' => 4,
+		]);
+		$table->addColumn('nc_session_id', Types::STRING, [
+			'notnull' => true,
+			'length' => 200,
+		]);
+		$table->addColumn('created_at', Types::BIGINT, [
+			'notnull' => true,
+			'length' => 20,
+			'unsigned' => true,
+		]);
+		$table->setPrimaryKey(['id']);
+		$table->addUniqueIndex(['sid']);
+
+		return $schema;
+	}
+}

--- a/lib/Migration/Version01021Date20220719114355.php
+++ b/lib/Migration/Version01021Date20220719114355.php
@@ -60,6 +60,8 @@ class Version01021Date20220719114355 extends SimpleMigrationStep {
 		]);
 		$table->setPrimaryKey(['id']);
 		$table->addUniqueIndex(['sid']);
+		$table->addUniqueIndex(['created_at']);
+		$table->addUniqueIndex(['nc_session_id']);
 
 		return $schema;
 	}

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -67,7 +67,8 @@
 					<div class="oidcproviders__details">
 						<b>{{ provider.identifier }}</b><br>
 						{{ t('user_oidc', 'Client ID') }}: {{ provider.clientId }}<br>
-						{{ t('user_oidc', 'Discovery endpoint') }}: {{ provider.discoveryEndpoint }}
+						{{ t('user_oidc', 'Discovery endpoint') }}: {{ provider.discoveryEndpoint }}<br>
+						{{ t('user_oidc', 'Backchannel Logout URL') }}: {{ getBackchannelUrl(provider) }}
 					</div>
 					<Actions>
 						<ActionButton icon="icon-rename" @click="updateProvider(provider)">
@@ -218,6 +219,10 @@ export default {
 				logger.error('Could not register a provider: ' + error.message, { error })
 				showError(t('user_oidc', 'Could not register provider:') + ' ' + (error.response?.data?.message ?? error.message))
 			}
+		},
+		getBackchannelUrl(provider) {
+			return window.location.protocol + '//' + window.location.host
+				+ generateUrl('/apps/user_oidc/backchannel-logout/{identifier}', { identifier: provider.identifier })
 		},
 	},
 }


### PR DESCRIPTION
closes #447

More commits will come with instructions to configure backchannel logout on the OP and the RP.

I tried to respect those specs as much as possible: https://openid.net/specs/openid-connect-backchannel-1_0.html

As we receive a logout token in the backchannel logout request, we get the sub and sid. IMO checking the sid is enough to identify the session.

So, on login, we store the relation between the session ID (of the ISession, not the IUserSession) and the ID token's `sid` attribute.

On backchannel logout, we get the session ID from the `sid` and we invalidate this session. Some more cleanup might be needed because the sid/sessionId links are not deleted when a session expires for example.