### PR TITLE
change log message to debug to address over-logging in #475

### DIFF
--- a/lib/User/Backend.php
+++ b/lib/User/Backend.php
@@ -296,7 +296,7 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 			}
 		}
 
-		$this->logger->error('Could not find unique token validation');
+		$this->logger->debug('Could not find unique token validation');
 		return '';
 	}
 


### PR DESCRIPTION
see issue #475, this happens when "Check bearer token on API and WebDav requests" is disabled and writes to the log for every webdav/caldav request (which can be a lot), seems like this should rather be logged as `debug`