### PR TITLE
Bump @nextcloud/vue, vue and vue-template-compiler

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -44,7 +44,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres
+        image: postgres:14
         ports:
           - 4445:5432/tcp
         env:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -39,7 +39,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres
+        image: postgres:14
         ports:
           - 4445:5432/tcp
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
 				"@nextcloud/initial-state": "^2.0.0",
 				"@nextcloud/logger": "^2.3.0",
 				"@nextcloud/router": "^2.0.0",
-				"@nextcloud/vue": "^5.4.0",
+				"@nextcloud/vue": "^7.0.0",
 				"vue": "^2.7.13",
 				"vue-material-design-icons": "^5.1.2"
 			},
@@ -22,7 +22,7 @@
 				"@nextcloud/babel-config": "^1.0.0",
 				"@nextcloud/browserslist-config": "^2.3.0",
 				"@nextcloud/eslint-config": "^8.1.2",
-				"@nextcloud/stylelint-config": "^2.2.0",
+				"@nextcloud/stylelint-config": "^2.3.0",
 				"@nextcloud/webpack-vue-config": "^5.3.0",
 				"vue-template-compiler": "^2.7.13"
 			},
@@ -1577,23 +1577,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"node_modules/@babel/polyfill": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
-			"integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
-			"deprecated": "🚨 This package has been deprecated in favor of separate inclusion of a polyfill and regenerator-runtime (when needed). See the @babel/polyfill docs (https://babeljs.io/docs/en/babel-polyfill) for more information.",
-			"dependencies": {
-				"core-js": "^2.6.5",
-				"regenerator-runtime": "^0.13.4"
-			}
-		},
-		"node_modules/@babel/polyfill/node_modules/core-js": {
-			"version": "2.6.12",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-			"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-			"deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-			"hasInstallScript": true
-		},
 		"node_modules/@babel/preset-env": {
 			"version": "7.18.10",
 			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.18.10.tgz",
@@ -1860,6 +1843,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@floating-ui/core": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.3.1.tgz",
+			"integrity": "sha512-ensKY7Ub59u16qsVIFEo2hwTCqZ/r9oZZFh51ivcLGHfUwTn8l1Xzng8RJUe91H/UP8PeqeBronAGx0qmzwk2g=="
+		},
+		"node_modules/@floating-ui/dom": {
+			"version": "0.1.10",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.1.10.tgz",
+			"integrity": "sha512-4kAVoogvQm2N0XE0G6APQJuCNuErjOfPW8Ux7DFxh8+AfugWflwVJ5LDlHOwrwut7z/30NUvdtHzQ3zSip4EzQ==",
+			"dependencies": {
+				"@floating-ui/core": "^0.3.0"
+			}
+		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.10.4",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
@@ -1925,6 +1921,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
 			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"dev": true,
 			"peer": true,
 			"engines": {
 				"node": ">=6.0.0"
@@ -1934,6 +1931,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
 			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"dev": true,
 			"peer": true,
 			"engines": {
 				"node": ">=6.0.0"
@@ -1943,6 +1941,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
 			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.0",
@@ -1953,6 +1952,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
 			"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@jridgewell/set-array": "^1.0.1",
@@ -1967,12 +1967,14 @@
 			"version": "1.4.14",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
 			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.15",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
 			"integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
@@ -2245,9 +2247,9 @@
 			}
 		},
 		"node_modules/@nextcloud/stylelint-config": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/stylelint-config/-/stylelint-config-2.2.0.tgz",
-			"integrity": "sha512-kH3pGAofdnDZJCTyYr2hc9Y63KVVrJ3845j3DOKJNW4uUVybiRZkMccwuJvT1mJ8Gn7lgETh4vceDXuwnJlJ3Q==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/stylelint-config/-/stylelint-config-2.3.0.tgz",
+			"integrity": "sha512-5mtWqqwrXFXekGT0I8PtVYxJAUQXYwMF28e2MBFbsbyCv+XVzFn9rOYAn6xUG1PrsIeEnom0xlQdrrjpJc71oA==",
 			"dev": true,
 			"engines": {
 				"node": "^16.0.0",
@@ -2268,114 +2270,43 @@
 			}
 		},
 		"node_modules/@nextcloud/vue": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-5.4.0.tgz",
-			"integrity": "sha512-YybOMuStBKtCwbssxMNEd0A8k/Qr5+zm9vnSOaLaMxeB8iaUU+PgBNiYGo8O24UJjSS6FqFwg02V4XzI1Sd6Lw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.0.0.tgz",
+			"integrity": "sha512-x+JAWCdL30qpxx4u4Ggdlg+l33f8ajX/qP5mZ3o4fshSDSZnz+d8kvnPoQXC6zRcdvNKzpgzCFe80I+G0q/QRQ==",
 			"dependencies": {
-				"@nextcloud/auth": "^1.2.3",
-				"@nextcloud/axios": "^1.3.2",
+				"@nextcloud/auth": "^2.0.0",
+				"@nextcloud/axios": "^2.0.0",
 				"@nextcloud/browser-storage": "^0.1.1",
 				"@nextcloud/calendar-js": "^3.0.0",
-				"@nextcloud/capabilities": "^1.0.2",
-				"@nextcloud/dialogs": "^3.0.0",
-				"@nextcloud/event-bus": "^2.0.0",
-				"@nextcloud/l10n": "^1.2.3",
-				"@nextcloud/logger": "^2.0.0",
+				"@nextcloud/capabilities": "^1.0.4",
+				"@nextcloud/dialogs": "^3.1.4",
+				"@nextcloud/event-bus": "^3.0.0",
+				"@nextcloud/initial-state": "^2.0.0",
+				"@nextcloud/l10n": "^1.6.0",
+				"@nextcloud/logger": "^2.2.1",
 				"@nextcloud/router": "^2.0.0",
 				"debounce": "1.2.1",
-				"emoji-mart-vue-fast": "^10.2.1",
+				"emoji-mart-vue-fast": "^11.1.1",
 				"escape-html": "^1.0.3",
-				"focus-trap": "^6.8.1",
+				"floating-vue": "^1.0.0-beta.18",
+				"focus-trap": "^7.0.0",
 				"hammerjs": "^2.0.8",
-				"linkify-string": "^3.0.2",
-				"md5": "^2.2.1",
-				"splitpanes": "^2.3.6",
-				"string-length": "^5.0.0",
-				"striptags": "^3.1.1",
-				"style-loader": "^3.3.1",
+				"linkify-string": "^4.0.0",
+				"md5": "^2.3.0",
+				"splitpanes": "^2.4.1",
+				"string-length": "^5.0.1",
+				"striptags": "^3.2.0",
 				"tributejs": "^5.1.3",
-				"v-click-outside": "^3.0.1",
-				"v-tooltip": "^2.0.3",
-				"vue": "^2.6.14",
-				"vue-color": "^2.7.1",
-				"vue-material-design-icons": "^5.0.0",
+				"v-click-outside": "^3.2.0",
+				"vue": "^2.7.8",
+				"vue-color": "^2.8.1",
+				"vue-material-design-icons": "^5.1.2",
 				"vue-multiselect": "^2.1.6",
-				"vue2-datepicker": "^3.6.3"
-			},
-			"engines": {
-				"node": "^14.0.0",
-				"npm": "^7.0.0"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@nextcloud/auth": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-1.3.0.tgz",
-			"integrity": "sha512-GfwRM9W7hat4psNdAt74UHEV+drEXQ53klCVp6JpON66ZLPeK5eJ1LQuiQDkpUxZpqNeaumXjiB98h5cug/uQw==",
-			"dependencies": {
-				"@nextcloud/event-bus": "^1.1.3",
-				"@nextcloud/typings": "^0.2.2",
-				"core-js": "^3.6.4"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@nextcloud/auth/node_modules/@nextcloud/event-bus": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-1.3.0.tgz",
-			"integrity": "sha512-+U5MnCvfnNWvf0lvdqJg8F+Nm8wN+s9ayuBjtiEQxTAcootv7lOnlMgfreqF3l2T0Wet2uZh4JbFVUWf8l3w7g==",
-			"dependencies": {
-				"@types/semver": "^7.3.5",
-				"core-js": "^3.11.2",
-				"semver": "^7.3.5"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@nextcloud/axios": {
-			"version": "1.11.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-1.11.0.tgz",
-			"integrity": "sha512-NyaiSC2GX2CPaH/MUGGMTTTza/TW9ZqWNGWq6LJ+pLER8nqZ9BQkwJ5kXUYGo+i3cka68PO+9WhcDv4fSABpuQ==",
-			"dependencies": {
-				"@nextcloud/auth": "^1.3.0",
-				"axios": "^0.27.1",
-				"core-js": "^3.6.4"
+				"vue2-datepicker": "^3.11.0"
 			},
 			"engines": {
 				"node": "^16.0.0",
 				"npm": "^7.0.0 || ^8.0.0"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@nextcloud/event-bus": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-2.1.1.tgz",
-			"integrity": "sha512-YEui6N+23uyjBSIUZhf8rEjG9vol7UGgxcgxMddEbO0HS7M/sh1cocRqtn+ZVi/yPybeToGmt68SDPCgwHQHKw==",
-			"dependencies": {
-				"@types/semver": "^7.1.0",
-				"core-js": "^3.6.2",
-				"semver": "^7.3.2"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@nextcloud/typings": {
-			"version": "0.2.4",
-			"resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-0.2.4.tgz",
-			"integrity": "sha512-49M8XUDQH27VIQE+13KrqSOYcyOsDUk6Yfw17jbBVtXFoDJ3YBSYYq8YaKeAM3Lz2JVbEpqQW9suAT+EyYSb6g==",
-			"dependencies": {
-				"@types/jquery": "2.0.54"
-			}
-		},
-		"node_modules/@nextcloud/vue/node_modules/@types/jquery": {
-			"version": "2.0.54",
-			"resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.54.tgz",
-			"integrity": "sha512-D/PomKwNkDfSKD13DEVQT/pq2TUjN54c6uB341fEZanIzkjfGe7UaFuuaLZbpEiS5j7Wk2MUHAZqZIoECw29lg=="
-		},
-		"node_modules/@nextcloud/vue/node_modules/semver": {
-			"version": "7.3.7",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-			"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"bin": {
-				"semver": "bin/semver.js"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/@nextcloud/webpack-vue-config": {
@@ -2486,6 +2417,7 @@
 			"version": "8.4.6",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
 			"integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@types/estree": "*",
@@ -2496,6 +2428,7 @@
 			"version": "3.7.4",
 			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
 			"integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@types/eslint": "*",
@@ -2506,6 +2439,7 @@
 			"version": "0.0.51",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
 			"integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/@types/express": {
@@ -2552,6 +2486,7 @@
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
 			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/@types/json5": {
@@ -2579,6 +2514,7 @@
 			"version": "18.7.14",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.14.tgz",
 			"integrity": "sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/@types/normalize-package-data": {
@@ -2739,6 +2675,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
 			"integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/helper-numbers": "1.11.1",
@@ -2749,24 +2686,28 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
 			"integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/@webassemblyjs/helper-api-error": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
 			"integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/@webassemblyjs/helper-buffer": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
 			"integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/@webassemblyjs/helper-numbers": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
 			"integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/floating-point-hex-parser": "1.11.1",
@@ -2778,12 +2719,14 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
 			"integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/@webassemblyjs/helper-wasm-section": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
 			"integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -2796,6 +2739,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
 			"integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@xtuc/ieee754": "^1.2.0"
@@ -2805,6 +2749,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
 			"integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@xtuc/long": "4.2.2"
@@ -2814,12 +2759,14 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
 			"integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/@webassemblyjs/wasm-edit": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
 			"integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -2836,6 +2783,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
 			"integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -2849,6 +2797,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
 			"integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -2861,6 +2810,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
 			"integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -2875,6 +2825,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
 			"integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -2924,12 +2875,14 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
 			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/@xtuc/long": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/abort-controller": {
@@ -2963,6 +2916,7 @@
 			"version": "8.8.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
 			"integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+			"dev": true,
 			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
@@ -2975,6 +2929,7 @@
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
 			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+			"dev": true,
 			"peer": true,
 			"peerDependencies": {
 				"acorn": "^8"
@@ -2994,6 +2949,7 @@
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
@@ -3052,6 +3008,7 @@
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+			"dev": true,
 			"peer": true,
 			"peerDependencies": {
 				"ajv": "^6.9.1"
@@ -3613,6 +3570,7 @@
 			"version": "4.21.3",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
 			"integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -3666,6 +3624,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/buffer-xor": {
@@ -3774,6 +3733,7 @@
 			"version": "1.0.30001388",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001388.tgz",
 			"integrity": "sha512-znVbq4OUjqgLxMxoNX2ZeeLR0d7lcDiE5uJ4eUiWdml1J1EkxbnQq6opT9jb9SMfJxB0XA16/ziHwni4u1I3GQ==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -3862,6 +3822,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+			"dev": true,
 			"peer": true,
 			"engines": {
 				"node": ">=6.0"
@@ -3957,6 +3918,7 @@
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/comment-parser": {
@@ -4673,6 +4635,7 @@
 			"version": "1.4.240",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.240.tgz",
 			"integrity": "sha512-r20dUOtZ4vUPTqAajDGonIM1uas5tf85Up+wPdtNBNvBSqGCfkpvMVvQ1T8YJzPV9/Y9g3FbUDcXb94Rafycow==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/elliptic": {
@@ -4699,12 +4662,12 @@
 			"peer": true
 		},
 		"node_modules/emoji-mart-vue-fast": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-10.2.2.tgz",
-			"integrity": "sha512-SO37LI60Oksog3RhNpEUoQjfceBXfZ3yW9ALhlQgyut7hE6MghHsBJrGPeI6KKK8bQfTMBYlci/RWKsUsmbkPw==",
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-11.2.0.tgz",
+			"integrity": "sha512-dEVAJAbQop+efR8Zn4bvPQtSREwsVZccQxEBHdi1GNPO0JC9H6l0FswuCli/TrZXAQr1KS7dGEUhS9A1gURFRA==",
 			"dependencies": {
-				"@babel/polyfill": "^7.12.1",
-				"@babel/runtime": "^7.16.3",
+				"@babel/runtime": "^7.18.6",
+				"core-js": "^3.23.5",
 				"vue-virtual-scroller": "^1.0.10"
 			},
 			"peerDependencies": {
@@ -4742,6 +4705,7 @@
 			"version": "5.10.0",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
 			"integrity": "sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
@@ -4829,6 +4793,7 @@
 			"version": "0.9.3",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
 			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/es-shim-unscopables": {
@@ -4870,6 +4835,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
 			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"dev": true,
 			"peer": true,
 			"engines": {
 				"node": ">=6"
@@ -5275,6 +5241,7 @@
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
 			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"esrecurse": "^4.3.0",
@@ -5520,6 +5487,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"estraverse": "^5.2.0"
@@ -5532,6 +5500,7 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+			"dev": true,
 			"peer": true,
 			"engines": {
 				"node": ">=4.0"
@@ -5541,6 +5510,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
 			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"dev": true,
 			"peer": true,
 			"engines": {
 				"node": ">=4.0"
@@ -5587,6 +5557,7 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
 			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"dev": true,
 			"peer": true,
 			"engines": {
 				"node": ">=0.8.x"
@@ -5719,6 +5690,7 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/fast-glob": {
@@ -5755,6 +5727,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/fast-levenshtein": {
@@ -5925,12 +5898,24 @@
 			"dev": true,
 			"peer": true
 		},
-		"node_modules/focus-trap": {
-			"version": "6.9.4",
-			"resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.4.tgz",
-			"integrity": "sha512-v2NTsZe2FF59Y+sDykKY+XjqZ0cPfhq/hikWVL88BqLivnNiEffAsac6rP6H45ff9wG9LL5ToiDqrLEP9GX9mw==",
+		"node_modules/floating-vue": {
+			"version": "1.0.0-beta.18",
+			"resolved": "https://registry.npmjs.org/floating-vue/-/floating-vue-1.0.0-beta.18.tgz",
+			"integrity": "sha512-mRFc78szc1BTbhlCa4okb7wAGPuH/IID+yqJ+yrTMQ038H8WIAsPV/WFgWCaXqe8d1Z12LkMqiHDVorCJy8M2A==",
 			"dependencies": {
-				"tabbable": "^5.3.3"
+				"@floating-ui/dom": "^0.1.10",
+				"vue-resize": "^1.0.0"
+			},
+			"peerDependencies": {
+				"vue": "^2.6.10"
+			}
+		},
+		"node_modules/focus-trap": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.0.0.tgz",
+			"integrity": "sha512-uT4Bl8TwU+5vVAx/DHil/1eVS54k9unqhK/vGy2KSh7esPmqgC0koAB9J2sJ+vtj8+vmiFyGk2unLkhNLQaxoA==",
+			"dependencies": {
+				"tabbable": "^6.0.0"
 			}
 		},
 		"node_modules/follow-redirects": {
@@ -6160,6 +6145,7 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/global-modules": {
@@ -6245,6 +6231,7 @@
 			"version": "4.2.10",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
 			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/grapheme-splitter": {
@@ -7238,6 +7225,7 @@
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
 			"integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@types/node": "*",
@@ -7252,6 +7240,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
 			"peer": true,
 			"engines": {
 				"node": ">=8"
@@ -7261,6 +7250,7 @@
 			"version": "8.1.1",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
 			"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"has-flag": "^4.0.0"
@@ -7319,12 +7309,14 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
@@ -7396,23 +7388,24 @@
 			"peer": true
 		},
 		"node_modules/linkify-string": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/linkify-string/-/linkify-string-3.0.4.tgz",
-			"integrity": "sha512-OnNqqRjlYXaXipIAbBC8sDXsSumI1ftatzFg141Pw9HEXWjTVLFcMZoKbFupshqWRavtNJ6QHLa+u6AlxxgeRw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/linkify-string/-/linkify-string-4.0.2.tgz",
+			"integrity": "sha512-+HoBme50rPaKxh5TrEJqRLq4gphks1zj3cz6gMBKIHwJCFYVwHig8ii9aCzqGUz8DxF2otbq+Z3AJmKUnfOtKg==",
 			"peerDependencies": {
-				"linkifyjs": "^3.0.0"
+				"linkifyjs": "^4.0.0"
 			}
 		},
 		"node_modules/linkifyjs": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-3.0.5.tgz",
-			"integrity": "sha512-1Y9XQH65eQKA9p2xtk+zxvnTeQBG7rdAXSkUG97DmuI/Xhji9uaUzaWxRj6rf9YC0v8KKHkxav7tnLX82Sz5Fg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.0.2.tgz",
+			"integrity": "sha512-/VSoCZiglX0VMsXmL5PN3lRg45M86lrD9PskdkA2abWaTKap1bIcJ11LS4EE55bcUl9ZOR4eZ792UtQ9E/5xLA==",
 			"peer": true
 		},
 		"node_modules/loader-runner": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
 			"integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+			"dev": true,
 			"peer": true,
 			"engines": {
 				"node": ">=6.11.5"
@@ -7452,7 +7445,9 @@
 		"node_modules/lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/lodash.debounce": {
 			"version": "4.0.8",
@@ -7647,6 +7642,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/merge2": {
@@ -7858,6 +7854,7 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/node-forge": {
@@ -7922,6 +7919,7 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
 			"integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/normalize-package-data": {
@@ -8449,16 +8447,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/popper.js": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-			"integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-			"deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/popperjs"
-			}
-		},
 		"node_modules/postcss": {
 			"version": "8.4.16",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
@@ -8738,6 +8726,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true,
 			"peer": true,
 			"engines": {
 				"node": ">=6"
@@ -8815,6 +8804,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"safe-buffer": "^5.1.0"
@@ -9328,6 +9318,7 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
 			"peer": true
 		},
 		"node_modules/safer-buffer": {
@@ -9501,6 +9492,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
 			"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"randombytes": "^2.1.0"
@@ -9790,6 +9782,7 @@
 			"version": "0.5.21",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
 			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"buffer-from": "^1.0.0",
@@ -10132,6 +10125,8 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
 			"integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
+			"dev": true,
+			"peer": true,
 			"engines": {
 				"node": ">= 12.13.0"
 			},
@@ -10392,9 +10387,9 @@
 			"peer": true
 		},
 		"node_modules/tabbable": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
-			"integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.0.0.tgz",
+			"integrity": "sha512-SxhZErfHc3Yozz/HLAl/iPOxuIj8AtUw13NRewVOjFW7vbsqT1f3PuiHrPQbUkRcLNEgAedAv2DnjLtzynJXiw=="
 		},
 		"node_modules/table": {
 			"version": "6.8.0",
@@ -10441,6 +10436,7 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
 			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+			"dev": true,
 			"peer": true,
 			"engines": {
 				"node": ">=6"
@@ -10450,6 +10446,7 @@
 			"version": "5.15.0",
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
 			"integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.2",
@@ -10468,6 +10465,7 @@
 			"version": "5.3.6",
 			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
 			"integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "^0.3.14",
@@ -10502,6 +10500,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
 			"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.8",
@@ -10756,6 +10755,7 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.7.tgz",
 			"integrity": "sha512-iN/XYesmZ2RmmWAiI4Z5rq0YqSiv0brj9Ce9CfhNE4xIW2h+MFxcgkxIzZ+ShkFPUkjU3gQ+3oypadD3RAMtrg==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "opencollective",
@@ -10782,6 +10782,7 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"punycode": "^2.1.0"
@@ -10852,17 +10853,6 @@
 			"integrity": "sha512-QD0bDy38SHJXQBjgnllmkI/rbdiwmq9RC+/+pvrFjYJKTn8dtp7Penf9q1lLBta280fYG2q53mgLhQ+3l3z74w==",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/v-tooltip": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/v-tooltip/-/v-tooltip-2.1.3.tgz",
-			"integrity": "sha512-xXngyxLQTOx/yUEy50thb8te7Qo4XU6h4LZB6cvEfVd9mnysUxLEoYwGWDdqR+l69liKsy3IPkdYff3J1gAJ5w==",
-			"dependencies": {
-				"@babel/runtime": "^7.13.10",
-				"lodash": "^4.17.21",
-				"popper.js": "^1.16.1",
-				"vue-resize": "^1.0.1"
 			}
 		},
 		"node_modules/v8-compile-cache": {
@@ -11143,9 +11133,9 @@
 			"peer": true
 		},
 		"node_modules/vue-virtual-scroller": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/vue-virtual-scroller/-/vue-virtual-scroller-1.0.10.tgz",
-			"integrity": "sha512-Hn4qSBDhRY4XdngPioYy/ykDjrLX/NMm1fQXm/4UQQ/Xv1x8JbHGFZNftQowTcfICgN7yc31AKnUk1UGLJ2ndA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/vue-virtual-scroller/-/vue-virtual-scroller-1.1.1.tgz",
+			"integrity": "sha512-UFnIFNThsI0EBOqOtUB1rYIvrPfNajBHuqEPDO4mN5hYA9jWtdl5fz7HuFCsF5XJs1dQ3GbFIF5cXGxT6Zs3ZQ==",
 			"dependencies": {
 				"scrollparent": "^2.0.1",
 				"vue-observe-visibility": "^0.4.4",
@@ -11178,6 +11168,7 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
 			"integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"glob-to-regexp": "^0.4.1",
@@ -11201,6 +11192,7 @@
 			"version": "5.74.0",
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
 			"integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@types/eslint-scope": "^3.7.3",
@@ -11514,6 +11506,7 @@
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
 			"integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+			"dev": true,
 			"peer": true,
 			"engines": {
 				"node": ">=10.13.0"
@@ -11523,6 +11516,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
 			"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+			"dev": true,
 			"peer": true,
 			"dependencies": {
 				"@types/json-schema": "^7.0.8",
@@ -12808,22 +12802,6 @@
 				"@babel/helper-plugin-utils": "^7.18.6"
 			}
 		},
-		"@babel/polyfill": {
-			"version": "7.12.1",
-			"resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.12.1.tgz",
-			"integrity": "sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==",
-			"requires": {
-				"core-js": "^2.6.5",
-				"regenerator-runtime": "^0.13.4"
-			},
-			"dependencies": {
-				"core-js": {
-					"version": "2.6.12",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-					"integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ=="
-				}
-			}
-		},
 		"@babel/preset-env": {
 			"version": "7.18.10",
 			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.18.10.tgz",
@@ -13037,6 +13015,19 @@
 				}
 			}
 		},
+		"@floating-ui/core": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.3.1.tgz",
+			"integrity": "sha512-ensKY7Ub59u16qsVIFEo2hwTCqZ/r9oZZFh51ivcLGHfUwTn8l1Xzng8RJUe91H/UP8PeqeBronAGx0qmzwk2g=="
+		},
+		"@floating-ui/dom": {
+			"version": "0.1.10",
+			"resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.1.10.tgz",
+			"integrity": "sha512-4kAVoogvQm2N0XE0G6APQJuCNuErjOfPW8Ux7DFxh8+AfugWflwVJ5LDlHOwrwut7z/30NUvdtHzQ3zSip4EzQ==",
+			"requires": {
+				"@floating-ui/core": "^0.3.0"
+			}
+		},
 		"@humanwhocodes/config-array": {
 			"version": "0.10.4",
 			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.10.4.tgz",
@@ -13085,18 +13076,21 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
 			"integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+			"dev": true,
 			"peer": true
 		},
 		"@jridgewell/set-array": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
 			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+			"dev": true,
 			"peer": true
 		},
 		"@jridgewell/source-map": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
 			"integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@jridgewell/gen-mapping": "^0.3.0",
@@ -13107,6 +13101,7 @@
 					"version": "0.3.2",
 					"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
 					"integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+					"dev": true,
 					"peer": true,
 					"requires": {
 						"@jridgewell/set-array": "^1.0.1",
@@ -13120,12 +13115,14 @@
 			"version": "1.4.14",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
 			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+			"dev": true,
 			"peer": true
 		},
 		"@jridgewell/trace-mapping": {
 			"version": "0.3.15",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
 			"integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@jridgewell/resolve-uri": "^3.0.3",
@@ -13332,9 +13329,9 @@
 			}
 		},
 		"@nextcloud/stylelint-config": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/stylelint-config/-/stylelint-config-2.2.0.tgz",
-			"integrity": "sha512-kH3pGAofdnDZJCTyYr2hc9Y63KVVrJ3845j3DOKJNW4uUVybiRZkMccwuJvT1mJ8Gn7lgETh4vceDXuwnJlJ3Q==",
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/stylelint-config/-/stylelint-config-2.3.0.tgz",
+			"integrity": "sha512-5mtWqqwrXFXekGT0I8PtVYxJAUQXYwMF28e2MBFbsbyCv+XVzFn9rOYAn6xUG1PrsIeEnom0xlQdrrjpJc71oA==",
 			"dev": true,
 			"requires": {}
 		},
@@ -13347,104 +13344,39 @@
 			}
 		},
 		"@nextcloud/vue": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-5.4.0.tgz",
-			"integrity": "sha512-YybOMuStBKtCwbssxMNEd0A8k/Qr5+zm9vnSOaLaMxeB8iaUU+PgBNiYGo8O24UJjSS6FqFwg02V4XzI1Sd6Lw==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/@nextcloud/vue/-/vue-7.0.0.tgz",
+			"integrity": "sha512-x+JAWCdL30qpxx4u4Ggdlg+l33f8ajX/qP5mZ3o4fshSDSZnz+d8kvnPoQXC6zRcdvNKzpgzCFe80I+G0q/QRQ==",
 			"requires": {
-				"@nextcloud/auth": "^1.2.3",
-				"@nextcloud/axios": "^1.3.2",
+				"@nextcloud/auth": "^2.0.0",
+				"@nextcloud/axios": "^2.0.0",
 				"@nextcloud/browser-storage": "^0.1.1",
 				"@nextcloud/calendar-js": "^3.0.0",
-				"@nextcloud/capabilities": "^1.0.2",
-				"@nextcloud/dialogs": "^3.0.0",
-				"@nextcloud/event-bus": "^2.0.0",
-				"@nextcloud/l10n": "^1.2.3",
-				"@nextcloud/logger": "^2.0.0",
+				"@nextcloud/capabilities": "^1.0.4",
+				"@nextcloud/dialogs": "^3.1.4",
+				"@nextcloud/event-bus": "^3.0.0",
+				"@nextcloud/initial-state": "^2.0.0",
+				"@nextcloud/l10n": "^1.6.0",
+				"@nextcloud/logger": "^2.2.1",
 				"@nextcloud/router": "^2.0.0",
 				"debounce": "1.2.1",
-				"emoji-mart-vue-fast": "^10.2.1",
+				"emoji-mart-vue-fast": "^11.1.1",
 				"escape-html": "^1.0.3",
-				"focus-trap": "^6.8.1",
+				"floating-vue": "^1.0.0-beta.18",
+				"focus-trap": "^7.0.0",
 				"hammerjs": "^2.0.8",
-				"linkify-string": "^3.0.2",
-				"md5": "^2.2.1",
-				"splitpanes": "^2.3.6",
-				"string-length": "^5.0.0",
-				"striptags": "^3.1.1",
-				"style-loader": "^3.3.1",
+				"linkify-string": "^4.0.0",
+				"md5": "^2.3.0",
+				"splitpanes": "^2.4.1",
+				"string-length": "^5.0.1",
+				"striptags": "^3.2.0",
 				"tributejs": "^5.1.3",
-				"v-click-outside": "^3.0.1",
-				"v-tooltip": "^2.0.3",
-				"vue": "^2.6.14",
-				"vue-color": "^2.7.1",
-				"vue-material-design-icons": "^5.0.0",
+				"v-click-outside": "^3.2.0",
+				"vue": "^2.7.8",
+				"vue-color": "^2.8.1",
+				"vue-material-design-icons": "^5.1.2",
 				"vue-multiselect": "^2.1.6",
-				"vue2-datepicker": "^3.6.3"
-			},
-			"dependencies": {
-				"@nextcloud/auth": {
-					"version": "1.3.0",
-					"resolved": "https://registry.npmjs.org/@nextcloud/auth/-/auth-1.3.0.tgz",
-					"integrity": "sha512-GfwRM9W7hat4psNdAt74UHEV+drEXQ53klCVp6JpON66ZLPeK5eJ1LQuiQDkpUxZpqNeaumXjiB98h5cug/uQw==",
-					"requires": {
-						"@nextcloud/event-bus": "^1.1.3",
-						"@nextcloud/typings": "^0.2.2",
-						"core-js": "^3.6.4"
-					},
-					"dependencies": {
-						"@nextcloud/event-bus": {
-							"version": "1.3.0",
-							"resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-1.3.0.tgz",
-							"integrity": "sha512-+U5MnCvfnNWvf0lvdqJg8F+Nm8wN+s9ayuBjtiEQxTAcootv7lOnlMgfreqF3l2T0Wet2uZh4JbFVUWf8l3w7g==",
-							"requires": {
-								"@types/semver": "^7.3.5",
-								"core-js": "^3.11.2",
-								"semver": "^7.3.5"
-							}
-						}
-					}
-				},
-				"@nextcloud/axios": {
-					"version": "1.11.0",
-					"resolved": "https://registry.npmjs.org/@nextcloud/axios/-/axios-1.11.0.tgz",
-					"integrity": "sha512-NyaiSC2GX2CPaH/MUGGMTTTza/TW9ZqWNGWq6LJ+pLER8nqZ9BQkwJ5kXUYGo+i3cka68PO+9WhcDv4fSABpuQ==",
-					"requires": {
-						"@nextcloud/auth": "^1.3.0",
-						"axios": "^0.27.1",
-						"core-js": "^3.6.4"
-					}
-				},
-				"@nextcloud/event-bus": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/@nextcloud/event-bus/-/event-bus-2.1.1.tgz",
-					"integrity": "sha512-YEui6N+23uyjBSIUZhf8rEjG9vol7UGgxcgxMddEbO0HS7M/sh1cocRqtn+ZVi/yPybeToGmt68SDPCgwHQHKw==",
-					"requires": {
-						"@types/semver": "^7.1.0",
-						"core-js": "^3.6.2",
-						"semver": "^7.3.2"
-					}
-				},
-				"@nextcloud/typings": {
-					"version": "0.2.4",
-					"resolved": "https://registry.npmjs.org/@nextcloud/typings/-/typings-0.2.4.tgz",
-					"integrity": "sha512-49M8XUDQH27VIQE+13KrqSOYcyOsDUk6Yfw17jbBVtXFoDJ3YBSYYq8YaKeAM3Lz2JVbEpqQW9suAT+EyYSb6g==",
-					"requires": {
-						"@types/jquery": "2.0.54"
-					}
-				},
-				"@types/jquery": {
-					"version": "2.0.54",
-					"resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-2.0.54.tgz",
-					"integrity": "sha512-D/PomKwNkDfSKD13DEVQT/pq2TUjN54c6uB341fEZanIzkjfGe7UaFuuaLZbpEiS5j7Wk2MUHAZqZIoECw29lg=="
-				},
-				"semver": {
-					"version": "7.3.7",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-					"integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-					"requires": {
-						"lru-cache": "^6.0.0"
-					}
-				}
+				"vue2-datepicker": "^3.11.0"
 			}
 		},
 		"@nextcloud/webpack-vue-config": {
@@ -13529,6 +13461,7 @@
 			"version": "8.4.6",
 			"resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
 			"integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@types/estree": "*",
@@ -13539,6 +13472,7 @@
 			"version": "3.7.4",
 			"resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.4.tgz",
 			"integrity": "sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@types/eslint": "*",
@@ -13549,6 +13483,7 @@
 			"version": "0.0.51",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
 			"integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
+			"dev": true,
 			"peer": true
 		},
 		"@types/express": {
@@ -13595,6 +13530,7 @@
 			"version": "7.0.11",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
 			"integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
+			"dev": true,
 			"peer": true
 		},
 		"@types/json5": {
@@ -13622,6 +13558,7 @@
 			"version": "18.7.14",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.14.tgz",
 			"integrity": "sha512-6bbDaETVi8oyIARulOE9qF1/Qdi/23z6emrUh0fNJRUmjznqrixD4MpGDdgOFk5Xb0m2H6Xu42JGdvAxaJR/wA==",
+			"dev": true,
 			"peer": true
 		},
 		"@types/normalize-package-data": {
@@ -13775,6 +13712,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
 			"integrity": "sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@webassemblyjs/helper-numbers": "1.11.1",
@@ -13785,24 +13723,28 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz",
 			"integrity": "sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==",
+			"dev": true,
 			"peer": true
 		},
 		"@webassemblyjs/helper-api-error": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz",
 			"integrity": "sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==",
+			"dev": true,
 			"peer": true
 		},
 		"@webassemblyjs/helper-buffer": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz",
 			"integrity": "sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==",
+			"dev": true,
 			"peer": true
 		},
 		"@webassemblyjs/helper-numbers": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz",
 			"integrity": "sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@webassemblyjs/floating-point-hex-parser": "1.11.1",
@@ -13814,12 +13756,14 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz",
 			"integrity": "sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==",
+			"dev": true,
 			"peer": true
 		},
 		"@webassemblyjs/helper-wasm-section": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz",
 			"integrity": "sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -13832,6 +13776,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz",
 			"integrity": "sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@xtuc/ieee754": "^1.2.0"
@@ -13841,6 +13786,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz",
 			"integrity": "sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@xtuc/long": "4.2.2"
@@ -13850,12 +13796,14 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz",
 			"integrity": "sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==",
+			"dev": true,
 			"peer": true
 		},
 		"@webassemblyjs/wasm-edit": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz",
 			"integrity": "sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -13872,6 +13820,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz",
 			"integrity": "sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -13885,6 +13834,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz",
 			"integrity": "sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -13897,6 +13847,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz",
 			"integrity": "sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -13911,6 +13862,7 @@
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz",
 			"integrity": "sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@webassemblyjs/ast": "1.11.1",
@@ -13947,12 +13899,14 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
 			"integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+			"dev": true,
 			"peer": true
 		},
 		"@xtuc/long": {
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
 			"integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+			"dev": true,
 			"peer": true
 		},
 		"abort-controller": {
@@ -13980,12 +13934,14 @@
 			"version": "8.8.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
 			"integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+			"dev": true,
 			"peer": true
 		},
 		"acorn-import-assertions": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
 			"integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
+			"dev": true,
 			"peer": true,
 			"requires": {}
 		},
@@ -14001,6 +13957,7 @@
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
@@ -14045,6 +14002,7 @@
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
 			"integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+			"dev": true,
 			"peer": true,
 			"requires": {}
 		},
@@ -14505,6 +14463,7 @@
 			"version": "4.21.3",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
 			"integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"caniuse-lite": "^1.0.30001370",
@@ -14528,6 +14487,7 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+			"dev": true,
 			"peer": true
 		},
 		"buffer-xor": {
@@ -14614,6 +14574,7 @@
 			"version": "1.0.30001388",
 			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001388.tgz",
 			"integrity": "sha512-znVbq4OUjqgLxMxoNX2ZeeLR0d7lcDiE5uJ4eUiWdml1J1EkxbnQq6opT9jb9SMfJxB0XA16/ziHwni4u1I3GQ==",
+			"dev": true,
 			"peer": true
 		},
 		"chalk": {
@@ -14671,6 +14632,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
 			"integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+			"dev": true,
 			"peer": true
 		},
 		"cipher-base": {
@@ -14756,6 +14718,7 @@
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true,
 			"peer": true
 		},
 		"comment-parser": {
@@ -15327,6 +15290,7 @@
 			"version": "1.4.240",
 			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.240.tgz",
 			"integrity": "sha512-r20dUOtZ4vUPTqAajDGonIM1uas5tf85Up+wPdtNBNvBSqGCfkpvMVvQ1T8YJzPV9/Y9g3FbUDcXb94Rafycow==",
+			"dev": true,
 			"peer": true
 		},
 		"elliptic": {
@@ -15355,12 +15319,12 @@
 			}
 		},
 		"emoji-mart-vue-fast": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-10.2.2.tgz",
-			"integrity": "sha512-SO37LI60Oksog3RhNpEUoQjfceBXfZ3yW9ALhlQgyut7hE6MghHsBJrGPeI6KKK8bQfTMBYlci/RWKsUsmbkPw==",
+			"version": "11.2.0",
+			"resolved": "https://registry.npmjs.org/emoji-mart-vue-fast/-/emoji-mart-vue-fast-11.2.0.tgz",
+			"integrity": "sha512-dEVAJAbQop+efR8Zn4bvPQtSREwsVZccQxEBHdi1GNPO0JC9H6l0FswuCli/TrZXAQr1KS7dGEUhS9A1gURFRA==",
 			"requires": {
-				"@babel/polyfill": "^7.12.1",
-				"@babel/runtime": "^7.16.3",
+				"@babel/runtime": "^7.18.6",
+				"core-js": "^3.23.5",
 				"vue-virtual-scroller": "^1.0.10"
 			}
 		},
@@ -15389,6 +15353,7 @@
 			"version": "5.10.0",
 			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz",
 			"integrity": "sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"graceful-fs": "^4.2.4",
@@ -15455,6 +15420,7 @@
 			"version": "0.9.3",
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
 			"integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
+			"dev": true,
 			"peer": true
 		},
 		"es-shim-unscopables": {
@@ -15490,6 +15456,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
 			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+			"dev": true,
 			"peer": true
 		},
 		"escape-html": {
@@ -15896,6 +15863,7 @@
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
 			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"esrecurse": "^4.3.0",
@@ -15963,6 +15931,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"estraverse": "^5.2.0"
@@ -15972,6 +15941,7 @@
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 					"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+					"dev": true,
 					"peer": true
 				}
 			}
@@ -15980,6 +15950,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
 			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"dev": true,
 			"peer": true
 		},
 		"esutils": {
@@ -16014,6 +15985,7 @@
 			"version": "3.3.0",
 			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
 			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"dev": true,
 			"peer": true
 		},
 		"evp_bytestokey": {
@@ -16122,6 +16094,7 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+			"dev": true,
 			"peer": true
 		},
 		"fast-glob": {
@@ -16154,6 +16127,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true,
 			"peer": true
 		},
 		"fast-levenshtein": {
@@ -16293,12 +16267,21 @@
 			"dev": true,
 			"peer": true
 		},
-		"focus-trap": {
-			"version": "6.9.4",
-			"resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-6.9.4.tgz",
-			"integrity": "sha512-v2NTsZe2FF59Y+sDykKY+XjqZ0cPfhq/hikWVL88BqLivnNiEffAsac6rP6H45ff9wG9LL5ToiDqrLEP9GX9mw==",
+		"floating-vue": {
+			"version": "1.0.0-beta.18",
+			"resolved": "https://registry.npmjs.org/floating-vue/-/floating-vue-1.0.0-beta.18.tgz",
+			"integrity": "sha512-mRFc78szc1BTbhlCa4okb7wAGPuH/IID+yqJ+yrTMQ038H8WIAsPV/WFgWCaXqe8d1Z12LkMqiHDVorCJy8M2A==",
 			"requires": {
-				"tabbable": "^5.3.3"
+				"@floating-ui/dom": "^0.1.10",
+				"vue-resize": "^1.0.0"
+			}
+		},
+		"focus-trap": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.0.0.tgz",
+			"integrity": "sha512-uT4Bl8TwU+5vVAx/DHil/1eVS54k9unqhK/vGy2KSh7esPmqgC0koAB9J2sJ+vtj8+vmiFyGk2unLkhNLQaxoA==",
+			"requires": {
+				"tabbable": "^6.0.0"
 			}
 		},
 		"follow-redirects": {
@@ -16462,6 +16445,7 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+			"dev": true,
 			"peer": true
 		},
 		"global-modules": {
@@ -16531,6 +16515,7 @@
 			"version": "4.2.10",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
 			"integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+			"dev": true,
 			"peer": true
 		},
 		"grapheme-splitter": {
@@ -17251,6 +17236,7 @@
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
 			"integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@types/node": "*",
@@ -17262,12 +17248,14 @@
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true,
 					"peer": true
 				},
 				"supports-color": {
 					"version": "8.1.1",
 					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
 					"integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+					"dev": true,
 					"peer": true,
 					"requires": {
 						"has-flag": "^4.0.0"
@@ -17310,12 +17298,14 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+			"dev": true,
 			"peer": true
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true,
 			"peer": true
 		},
 		"json-stable-stringify-without-jsonify": {
@@ -17372,21 +17362,22 @@
 			"peer": true
 		},
 		"linkify-string": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/linkify-string/-/linkify-string-3.0.4.tgz",
-			"integrity": "sha512-OnNqqRjlYXaXipIAbBC8sDXsSumI1ftatzFg141Pw9HEXWjTVLFcMZoKbFupshqWRavtNJ6QHLa+u6AlxxgeRw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/linkify-string/-/linkify-string-4.0.2.tgz",
+			"integrity": "sha512-+HoBme50rPaKxh5TrEJqRLq4gphks1zj3cz6gMBKIHwJCFYVwHig8ii9aCzqGUz8DxF2otbq+Z3AJmKUnfOtKg==",
 			"requires": {}
 		},
 		"linkifyjs": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-3.0.5.tgz",
-			"integrity": "sha512-1Y9XQH65eQKA9p2xtk+zxvnTeQBG7rdAXSkUG97DmuI/Xhji9uaUzaWxRj6rf9YC0v8KKHkxav7tnLX82Sz5Fg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.0.2.tgz",
+			"integrity": "sha512-/VSoCZiglX0VMsXmL5PN3lRg45M86lrD9PskdkA2abWaTKap1bIcJ11LS4EE55bcUl9ZOR4eZ792UtQ9E/5xLA==",
 			"peer": true
 		},
 		"loader-runner": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
 			"integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+			"dev": true,
 			"peer": true
 		},
 		"loader-utils": {
@@ -17414,7 +17405,9 @@
 		"lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"dev": true,
+			"peer": true
 		},
 		"lodash.debounce": {
 			"version": "4.0.8",
@@ -17574,6 +17567,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
 			"integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+			"dev": true,
 			"peer": true
 		},
 		"merge2": {
@@ -17739,6 +17733,7 @@
 			"version": "2.6.2",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+			"dev": true,
 			"peer": true
 		},
 		"node-forge": {
@@ -17794,6 +17789,7 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
 			"integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
+			"dev": true,
 			"peer": true
 		},
 		"normalize-package-data": {
@@ -18193,11 +18189,6 @@
 				}
 			}
 		},
-		"popper.js": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-			"integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
-		},
 		"postcss": {
 			"version": "8.4.16",
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.16.tgz",
@@ -18402,6 +18393,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true,
 			"peer": true
 		},
 		"qs": {
@@ -18446,6 +18438,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
 			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"safe-buffer": "^5.1.0"
@@ -18843,6 +18836,7 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true,
 			"peer": true
 		},
 		"safer-buffer": {
@@ -18970,6 +18964,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
 			"integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"randombytes": "^2.1.0"
@@ -19209,6 +19204,7 @@
 			"version": "0.5.21",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
 			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -19487,6 +19483,8 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
 			"integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
+			"dev": true,
+			"peer": true,
 			"requires": {}
 		},
 		"style-search": {
@@ -19680,9 +19678,9 @@
 			"peer": true
 		},
 		"tabbable": {
-			"version": "5.3.3",
-			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-5.3.3.tgz",
-			"integrity": "sha512-QD9qKY3StfbZqWOPLp0++pOrAVb/HbUi5xCc8cUo4XjP19808oaMiDzn0leBY5mCespIBM0CIZePzZjgzR83kA=="
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.0.0.tgz",
+			"integrity": "sha512-SxhZErfHc3Yozz/HLAl/iPOxuIj8AtUw13NRewVOjFW7vbsqT1f3PuiHrPQbUkRcLNEgAedAv2DnjLtzynJXiw=="
 		},
 		"table": {
 			"version": "6.8.0",
@@ -19724,12 +19722,14 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
 			"integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+			"dev": true,
 			"peer": true
 		},
 		"terser": {
 			"version": "5.15.0",
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
 			"integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@jridgewell/source-map": "^0.3.2",
@@ -19742,6 +19742,7 @@
 			"version": "5.3.6",
 			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
 			"integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@jridgewell/trace-mapping": "^0.3.14",
@@ -19755,6 +19756,7 @@
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
 					"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+					"dev": true,
 					"peer": true,
 					"requires": {
 						"@types/json-schema": "^7.0.8",
@@ -19955,6 +19957,7 @@
 			"version": "1.0.7",
 			"resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.7.tgz",
 			"integrity": "sha512-iN/XYesmZ2RmmWAiI4Z5rq0YqSiv0brj9Ce9CfhNE4xIW2h+MFxcgkxIzZ+ShkFPUkjU3gQ+3oypadD3RAMtrg==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"escalade": "^3.1.1",
@@ -19965,6 +19968,7 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"punycode": "^2.1.0"
@@ -20029,17 +20033,6 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/v-click-outside/-/v-click-outside-3.2.0.tgz",
 			"integrity": "sha512-QD0bDy38SHJXQBjgnllmkI/rbdiwmq9RC+/+pvrFjYJKTn8dtp7Penf9q1lLBta280fYG2q53mgLhQ+3l3z74w=="
-		},
-		"v-tooltip": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/v-tooltip/-/v-tooltip-2.1.3.tgz",
-			"integrity": "sha512-xXngyxLQTOx/yUEy50thb8te7Qo4XU6h4LZB6cvEfVd9mnysUxLEoYwGWDdqR+l69liKsy3IPkdYff3J1gAJ5w==",
-			"requires": {
-				"@babel/runtime": "^7.13.10",
-				"lodash": "^4.17.21",
-				"popper.js": "^1.16.1",
-				"vue-resize": "^1.0.1"
-			}
 		},
 		"v8-compile-cache": {
 			"version": "2.3.0",
@@ -20267,9 +20260,9 @@
 			"peer": true
 		},
 		"vue-virtual-scroller": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/vue-virtual-scroller/-/vue-virtual-scroller-1.0.10.tgz",
-			"integrity": "sha512-Hn4qSBDhRY4XdngPioYy/ykDjrLX/NMm1fQXm/4UQQ/Xv1x8JbHGFZNftQowTcfICgN7yc31AKnUk1UGLJ2ndA==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/vue-virtual-scroller/-/vue-virtual-scroller-1.1.1.tgz",
+			"integrity": "sha512-UFnIFNThsI0EBOqOtUB1rYIvrPfNajBHuqEPDO4mN5hYA9jWtdl5fz7HuFCsF5XJs1dQ3GbFIF5cXGxT6Zs3ZQ==",
 			"requires": {
 				"scrollparent": "^2.0.1",
 				"vue-observe-visibility": "^0.4.4",
@@ -20296,6 +20289,7 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
 			"integrity": "sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"glob-to-regexp": "^0.4.1",
@@ -20316,6 +20310,7 @@
 			"version": "5.74.0",
 			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
 			"integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
+			"dev": true,
 			"peer": true,
 			"requires": {
 				"@types/eslint-scope": "^3.7.3",
@@ -20348,6 +20343,7 @@
 					"version": "3.1.1",
 					"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
 					"integrity": "sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==",
+					"dev": true,
 					"peer": true,
 					"requires": {
 						"@types/json-schema": "^7.0.8",
@@ -20544,6 +20540,7 @@
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
 			"integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+			"dev": true,
 			"peer": true
 		},
 		"websocket-driver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"@nextcloud/logger": "^2.3.0",
 				"@nextcloud/router": "^2.0.0",
 				"@nextcloud/vue": "^5.4.0",
-				"vue": "^2.7.9",
+				"vue": "^2.7.13",
 				"vue-material-design-icons": "^5.1.2"
 			},
 			"devDependencies": {
@@ -24,7 +24,7 @@
 				"@nextcloud/eslint-config": "^8.1.2",
 				"@nextcloud/stylelint-config": "^2.2.0",
 				"@nextcloud/webpack-vue-config": "^5.3.0",
-				"vue-template-compiler": "^2.7.9"
+				"vue-template-compiler": "^2.7.13"
 			},
 			"engines": {
 				"node": "^16.0.0",
@@ -2663,9 +2663,9 @@
 			}
 		},
 		"node_modules/@vue/compiler-sfc": {
-			"version": "2.7.10",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.10.tgz",
-			"integrity": "sha512-55Shns6WPxlYsz4WX7q9ZJBL77sKE1ZAYNYStLs6GbhIOMrNtjMvzcob6gu3cGlfpCR4bT7NXgyJ3tly2+Hx8Q==",
+			"version": "2.7.13",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.13.tgz",
+			"integrity": "sha512-zzu2rLRZlgIU+OT3Atbr7Y6PG+LW4wVQpPfNRrGDH3dM9PsrcVfa+1pKb8bW467bGM3aDOvAnsYLWVpYIv3GRg==",
 			"dependencies": {
 				"@babel/parser": "^7.18.4",
 				"postcss": "^8.4.14",
@@ -10901,11 +10901,11 @@
 			"peer": true
 		},
 		"node_modules/vue": {
-			"version": "2.7.10",
-			"resolved": "https://registry.npmjs.org/vue/-/vue-2.7.10.tgz",
-			"integrity": "sha512-HmFC70qarSHPXcKtW8U8fgIkF6JGvjEmDiVInTkKZP0gIlEPhlVlcJJLkdGIDiNkIeA2zJPQTWJUI4iWe+AVfg==",
+			"version": "2.7.13",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-2.7.13.tgz",
+			"integrity": "sha512-QnM6ULTNnPmn71eUO+4hdjfBIA3H0GLsBnchnI/kS678tjI45GOUZhXd0oP/gX9isikXz1PAzSnkPspp9EUNfQ==",
 			"dependencies": {
-				"@vue/compiler-sfc": "2.7.10",
+				"@vue/compiler-sfc": "2.7.13",
 				"csstype": "^3.1.0"
 			}
 		},
@@ -11126,9 +11126,9 @@
 			}
 		},
 		"node_modules/vue-template-compiler": {
-			"version": "2.7.10",
-			"resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.10.tgz",
-			"integrity": "sha512-QO+8R9YRq1Gudm8ZMdo/lImZLJVUIAM8c07Vp84ojdDAf8HmPJc7XB556PcXV218k2AkKznsRz6xB5uOjAC4EQ==",
+			"version": "2.7.13",
+			"resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.13.tgz",
+			"integrity": "sha512-jYM6TClwDS9YqP48gYrtAtaOhRKkbYmbzE+Q51gX5YDr777n7tNI/IZk4QV4l/PjQPNh/FVa/E92sh/RqKMrog==",
 			"dev": true,
 			"dependencies": {
 				"de-indent": "^1.0.2",
@@ -13706,9 +13706,9 @@
 			}
 		},
 		"@vue/compiler-sfc": {
-			"version": "2.7.10",
-			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.10.tgz",
-			"integrity": "sha512-55Shns6WPxlYsz4WX7q9ZJBL77sKE1ZAYNYStLs6GbhIOMrNtjMvzcob6gu3cGlfpCR4bT7NXgyJ3tly2+Hx8Q==",
+			"version": "2.7.13",
+			"resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.13.tgz",
+			"integrity": "sha512-zzu2rLRZlgIU+OT3Atbr7Y6PG+LW4wVQpPfNRrGDH3dM9PsrcVfa+1pKb8bW467bGM3aDOvAnsYLWVpYIv3GRg==",
 			"requires": {
 				"@babel/parser": "^7.18.4",
 				"postcss": "^8.4.14",
@@ -20074,11 +20074,11 @@
 			"peer": true
 		},
 		"vue": {
-			"version": "2.7.10",
-			"resolved": "https://registry.npmjs.org/vue/-/vue-2.7.10.tgz",
-			"integrity": "sha512-HmFC70qarSHPXcKtW8U8fgIkF6JGvjEmDiVInTkKZP0gIlEPhlVlcJJLkdGIDiNkIeA2zJPQTWJUI4iWe+AVfg==",
+			"version": "2.7.13",
+			"resolved": "https://registry.npmjs.org/vue/-/vue-2.7.13.tgz",
+			"integrity": "sha512-QnM6ULTNnPmn71eUO+4hdjfBIA3H0GLsBnchnI/kS678tjI45GOUZhXd0oP/gX9isikXz1PAzSnkPspp9EUNfQ==",
 			"requires": {
-				"@vue/compiler-sfc": "2.7.10",
+				"@vue/compiler-sfc": "2.7.13",
 				"csstype": "^3.1.0"
 			}
 		},
@@ -20250,9 +20250,9 @@
 			}
 		},
 		"vue-template-compiler": {
-			"version": "2.7.10",
-			"resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.10.tgz",
-			"integrity": "sha512-QO+8R9YRq1Gudm8ZMdo/lImZLJVUIAM8c07Vp84ojdDAf8HmPJc7XB556PcXV218k2AkKznsRz6xB5uOjAC4EQ==",
+			"version": "2.7.13",
+			"resolved": "https://registry.npmjs.org/vue-template-compiler/-/vue-template-compiler-2.7.13.tgz",
+			"integrity": "sha512-jYM6TClwDS9YqP48gYrtAtaOhRKkbYmbzE+Q51gX5YDr777n7tNI/IZk4QV4l/PjQPNh/FVa/E92sh/RqKMrog==",
 			"dev": true,
 			"requires": {
 				"de-indent": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"@nextcloud/logger": "^2.3.0",
 		"@nextcloud/router": "^2.0.0",
 		"@nextcloud/vue": "^5.4.0",
-		"vue": "^2.7.9",
+		"vue": "^2.7.13",
 		"vue-material-design-icons": "^5.1.2"
 	},
 	"browserslist": [
@@ -41,6 +41,6 @@
 		"@nextcloud/eslint-config": "^8.1.2",
 		"@nextcloud/stylelint-config": "^2.2.0",
 		"@nextcloud/webpack-vue-config": "^5.3.0",
-		"vue-template-compiler": "^2.7.9"
+		"vue-template-compiler": "^2.7.13"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"@nextcloud/initial-state": "^2.0.0",
 		"@nextcloud/logger": "^2.3.0",
 		"@nextcloud/router": "^2.0.0",
-		"@nextcloud/vue": "^5.4.0",
+		"@nextcloud/vue": "^7.0.0",
 		"vue": "^2.7.13",
 		"vue-material-design-icons": "^5.1.2"
 	},
@@ -39,7 +39,7 @@
 		"@nextcloud/babel-config": "^1.0.0",
 		"@nextcloud/browserslist-config": "^2.3.0",
 		"@nextcloud/eslint-config": "^8.1.2",
-		"@nextcloud/stylelint-config": "^2.2.0",
+		"@nextcloud/stylelint-config": "^2.3.0",
 		"@nextcloud/webpack-vue-config": "^5.3.0",
 		"vue-template-compiler": "^2.7.13"
 	}

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -27,27 +27,27 @@
 				{{ t('user_oidc', 'Allows users to authenticate via OpenID Connect providers.') }}
 			</p>
 			<p>
-				<CheckboxRadioSwitch :checked.sync="id4meState"
+				<NcCheckboxRadioSwitch :checked.sync="id4meState"
 					wrapper-element="div"
 					@update:checked="onId4MeChange">
 					{{ t('user_oidc', 'Enable ID4me') }}
-				</CheckboxRadioSwitch>
+				</NcCheckboxRadioSwitch>
 			</p>
 		</div>
 		<div class="section">
 			<h2>
 				{{ t('user_oidc', 'Registered Providers') }}
-				<Actions>
-					<ActionButton @click="showNewProvider=true">
+				<NcActions>
+					<NcActionButton @click="showNewProvider=true">
 						<template #icon>
 							<PlusIcon :size="20" />
 						</template>
 						{{ t('user_oidc', 'Register new provider') }}
-					</ActionButton>
-				</Actions>
+					</NcActionButton>
+				</NcActions>
 			</h2>
 
-			<Modal v-if="showNewProvider"
+			<NcModal v-if="showNewProvider"
 				size="large"
 				:can-close="false">
 				<div class="providermodal__wrapper">
@@ -57,7 +57,7 @@
 					</p>
 					<SettingsForm :provider="newProvider" @submit="onSubmit" @cancel="showNewProvider=false" />
 				</div>
-			</Modal>
+			</NcModal>
 
 			<div class="oidcproviders">
 				<p v-if="providers.length === 0">
@@ -73,26 +73,26 @@
 						{{ t('user_oidc', 'Discovery endpoint') }}: {{ provider.discoveryEndpoint }}<br>
 						{{ t('user_oidc', 'Backchannel Logout URL') }}: {{ getBackchannelUrl(provider) }}
 					</div>
-					<Actions>
-						<ActionButton @click="updateProvider(provider)">
+					<NcActions :style="customActionsStyle">
+						<NcActionButton @click="updateProvider(provider)">
 							<template #icon>
 								<PencilIcon :size="20" />
 							</template>
 							{{ t('user_oidc', 'Update') }}
-						</ActionButton>
-					</Actions>
-					<Actions>
-						<ActionButton @click="onRemove(provider)">
+						</NcActionButton>
+					</NcActions>
+					<NcActions :style="customActionsStyle">
+						<NcActionButton @click="onRemove(provider)">
 							<template #icon>
 								<DeleteIcon :size="20" />
 							</template>
 							{{ t('user_oidc', 'Remove') }}
-						</ActionButton>
-					</Actions>
+						</NcActionButton>
+					</NcActions>
 				</div>
 			</div>
 
-			<Modal v-if="editProvider"
+			<NcModal v-if="editProvider"
 				size="large"
 				:can-close="false">
 				<div class="providermodal__wrapper">
@@ -103,7 +103,7 @@
 						@submit="onUpdate"
 						@cancel="editProvider=null" />
 				</div>
-			</Modal>
+			</NcModal>
 		</div>
 	</div>
 </template>
@@ -116,10 +116,10 @@ import PlusIcon from 'vue-material-design-icons/Plus.vue'
 import axios from '@nextcloud/axios'
 import { generateUrl } from '@nextcloud/router'
 import { showError } from '@nextcloud/dialogs'
-import Actions from '@nextcloud/vue/dist/Components/Actions.js'
-import ActionButton from '@nextcloud/vue/dist/Components/ActionButton.js'
-import Modal from '@nextcloud/vue/dist/Components/Modal.js'
-import CheckboxRadioSwitch from '@nextcloud/vue/dist/Components/CheckboxRadioSwitch.js'
+import NcActions from '@nextcloud/vue/dist/Components/NcActions.js'
+import NcActionButton from '@nextcloud/vue/dist/Components/NcActionButton.js'
+import NcModal from '@nextcloud/vue/dist/Components/NcModal.js'
+import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
 
 import logger from '../logger.js'
 import SettingsForm from './SettingsForm.vue'
@@ -128,10 +128,10 @@ export default {
 	name: 'AdminSettings',
 	components: {
 		SettingsForm,
-		Actions,
-		ActionButton,
-		Modal,
-		CheckboxRadioSwitch,
+		NcActions,
+		NcActionButton,
+		NcModal,
+		NcCheckboxRadioSwitch,
 		PencilIcon,
 		DeleteIcon,
 		PlusIcon,
@@ -168,6 +168,9 @@ export default {
 			},
 			showNewProvider: false,
 			editProvider: null,
+			customActionsStyle: {
+				'--color-background-hover': 'var(--color-background-darker)',
+			},
 		}
 	},
 	methods: {
@@ -268,6 +271,7 @@ h3 {
 	border-bottom: 1px solid var(--color-border);
 	padding: 10px;
 	display: flex;
+	align-items: start;
 
 	&:hover {
 		background-color: var(--color-background-hover);

--- a/src/components/SettingsForm.vue
+++ b/src/components/SettingsForm.vue
@@ -100,21 +100,21 @@
 				type="text"
 				placeholder="quota">
 		</p>
-		<CheckboxRadioSwitch :checked.sync="localProvider.settings.uniqueUid" wrapper-element="div">
+		<NcCheckboxRadioSwitch :checked.sync="localProvider.settings.uniqueUid" wrapper-element="div">
 			{{ t('user_oidc', 'Use unique user id') }}
-		</CheckboxRadioSwitch>
+		</NcCheckboxRadioSwitch>
 		<p class="settings-hint">
 			{{ t('user_oidc', 'By default every user will get a unique userid that is a hashed value of the provider and user id. This can be turned off but uniqueness of users accross multiple user backends and providers is no longer preserved then.') }}
 		</p>
-		<CheckboxRadioSwitch :checked.sync="localProvider.settings.checkBearer" wrapper-element="div">
+		<NcCheckboxRadioSwitch :checked.sync="localProvider.settings.checkBearer" wrapper-element="div">
 			{{ t('user_oidc', 'Check Bearer token on API and WebDav requests') }}
-		</CheckboxRadioSwitch>
+		</NcCheckboxRadioSwitch>
 		<p class="settings-hint">
 			{{ t('user_oidc', 'Do you want to allow API calls and WebDav request that are authenticated with an OIDC ID token or access token?') }}
 		</p>
-		<CheckboxRadioSwitch :checked.sync="localProvider.settings.sendIdTokenHint" wrapper-element="div">
+		<NcCheckboxRadioSwitch :checked.sync="localProvider.settings.sendIdTokenHint" wrapper-element="div">
 			{{ t('user_oidc', 'Send ID token hint on logout') }}
-		</CheckboxRadioSwitch>
+		</NcCheckboxRadioSwitch>
 		<p class="settings-hint">
 			{{ t('user_oidc', 'Should the ID token be included as the id_token_hint GET parameter in the OpenID logout URL? Users are redirected to this URL after logging out of Nextcloud. Enabling this setting exposes the OIDC ID token to the user agent, which may not be necessary depending on the OIDC provider.') }}
 		</p>
@@ -136,13 +136,13 @@
 import AlertOutlineIcon from 'vue-material-design-icons/AlertOutline.vue'
 import CheckIcon from 'vue-material-design-icons/Check.vue'
 
-import CheckboxRadioSwitch from '@nextcloud/vue/dist/Components/CheckboxRadioSwitch.js'
-import NcButton from '@nextcloud/vue/dist/Components/Button.js'
+import NcCheckboxRadioSwitch from '@nextcloud/vue/dist/Components/NcCheckboxRadioSwitch.js'
+import NcButton from '@nextcloud/vue/dist/Components/NcButton.js'
 
 export default {
 	name: 'SettingsForm',
 	components: {
-		CheckboxRadioSwitch,
+		NcCheckboxRadioSwitch,
 		NcButton,
 		AlertOutlineIcon,
 		CheckIcon,


### PR DESCRIPTION
The ones from dependabot are outdated.

A few necessary adjustments in the provider list item:
* action buttons were streched, they are now aligned to the top
* hover color was the same for the provider item and the action buttons. For those buttons, `--color-background-hover` is now overridden by the value of `--color-background-darker`