### PR TITLE
Fix generated authorization url

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -290,9 +290,7 @@ class LoginController extends Controller {
 			return $response;
 		}
 
-		// sanitize the authorization_endpoint
-		$authorizationEndpoint = htmlentities(filter_var($discovery['authorization_endpoint'], FILTER_SANITIZE_URL), ENT_QUOTES);
-		$authorizationUrl = $authorizationEndpoint . '?' . http_build_query($data);
+		$authorizationUrl = $this->buildAuthorizationUrl($discovery['authorization_endpoint'], $data);
 
 		$this->logger->debug('Redirecting user to: ' . $authorizationUrl);
 
@@ -303,6 +301,32 @@ class LoginController extends Controller {
 		}
 
 		return new RedirectResponse($authorizationUrl);
+	}
+
+	/**
+	 * @param string $authorizationEndpoint
+	 * @param array $extraGetParameters
+	 * @return string
+	 */
+	private function buildAuthorizationUrl(string $authorizationEndpoint, array $extraGetParameters = []): string {
+		$parsedUrl = parse_url($authorizationEndpoint);
+
+		$urlWithoutParams =
+			(isset($parsedUrl['scheme']) ? $parsedUrl['scheme'] . '://' : '')
+			. ($parsedUrl['host'] ?? '')
+			. (isset($parsedUrl['port']) ? ':' . $parsedUrl['port'] : '')
+			. ($parsedUrl['path'] ?? '');
+
+		$queryParams = $extraGetParameters;
+		if (isset($parsedUrl['query'])) {
+			parse_str($parsedUrl['query'], $parsedQueryParams);
+			$queryParams = array_merge($queryParams, $parsedQueryParams);
+		}
+
+		// sanitize everything before the query parameters
+		// and trust http_build_query to sanitize the query parameters
+		return htmlentities(filter_var($urlWithoutParams, FILTER_SANITIZE_URL), ENT_QUOTES)
+			. (empty($queryParams) ? '' : '?' . http_build_query($queryParams));
 	}
 
 	/**

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -290,7 +290,7 @@ class LoginController extends Controller {
 			return $response;
 		}
 
-		$authorizationUrl = $this->buildAuthorizationUrl($discovery['authorization_endpoint'], $data);
+		$authorizationUrl = $this->discoveryService->buildAuthorizationUrl($discovery['authorization_endpoint'], $data);
 
 		$this->logger->debug('Redirecting user to: ' . $authorizationUrl);
 
@@ -301,32 +301,6 @@ class LoginController extends Controller {
 		}
 
 		return new RedirectResponse($authorizationUrl);
-	}
-
-	/**
-	 * @param string $authorizationEndpoint
-	 * @param array $extraGetParameters
-	 * @return string
-	 */
-	private function buildAuthorizationUrl(string $authorizationEndpoint, array $extraGetParameters = []): string {
-		$parsedUrl = parse_url($authorizationEndpoint);
-
-		$urlWithoutParams =
-			(isset($parsedUrl['scheme']) ? $parsedUrl['scheme'] . '://' : '')
-			. ($parsedUrl['host'] ?? '')
-			. (isset($parsedUrl['port']) ? ':' . $parsedUrl['port'] : '')
-			. ($parsedUrl['path'] ?? '');
-
-		$queryParams = $extraGetParameters;
-		if (isset($parsedUrl['query'])) {
-			parse_str($parsedUrl['query'], $parsedQueryParams);
-			$queryParams = array_merge($queryParams, $parsedQueryParams);
-		}
-
-		// sanitize everything before the query parameters
-		// and trust http_build_query to sanitize the query parameters
-		return htmlentities(filter_var($urlWithoutParams, FILTER_SANITIZE_URL), ENT_QUOTES)
-			. (empty($queryParams) ? '' : '?' . http_build_query($queryParams));
 	}
 
 	/**

--- a/lib/Service/DiscoveryService.php
+++ b/lib/Service/DiscoveryService.php
@@ -91,4 +91,30 @@ class DiscoveryService {
 		$this->logger->debug('Parsed the jwks');
 		return $jwks;
 	}
+
+	/**
+	 * @param string $authorizationEndpoint
+	 * @param array $extraGetParameters
+	 * @return string
+	 */
+	public function buildAuthorizationUrl(string $authorizationEndpoint, array $extraGetParameters = []): string {
+		$parsedUrl = parse_url($authorizationEndpoint);
+
+		$urlWithoutParams =
+			(isset($parsedUrl['scheme']) ? $parsedUrl['scheme'] . '://' : '')
+			. ($parsedUrl['host'] ?? '')
+			. (isset($parsedUrl['port']) ? ':' . $parsedUrl['port'] : '')
+			. ($parsedUrl['path'] ?? '');
+
+		$queryParams = $extraGetParameters;
+		if (isset($parsedUrl['query'])) {
+			parse_str($parsedUrl['query'], $parsedQueryParams);
+			$queryParams = array_merge($queryParams, $parsedQueryParams);
+		}
+
+		// sanitize everything before the query parameters
+		// and trust http_build_query to sanitize the query parameters
+		return htmlentities(filter_var($urlWithoutParams, FILTER_SANITIZE_URL), ENT_QUOTES)
+			. (empty($queryParams) ? '' : '?' . http_build_query($queryParams));
+	}
 }


### PR DESCRIPTION
Fix generated authorization url when the one from the discovery contains GET params: we merge them with the ones we add.
We keep sanitizing everything before the GET params.

@lauritzh I'm interested in your opinion on that :grin:.