### PR TITLE
Fix display name change

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -505,6 +505,11 @@ class LoginController extends Controller {
 			if ($newDisplayName !== $oldDisplayName) {
 				$backendUser->setDisplayName($newDisplayName);
 				$this->userMapper->update($backendUser);
+			}
+			// 2 reasons why we should update the display name: It does not match the one
+			// - of our backend
+			// - returned by the user manager (outdated one before the fix in https://github.com/nextcloud/user_oidc/pull/530)
+			if ($newDisplayName !== $oldDisplayName || $newDisplayName !== $this->userManager->getDisplayName($user->getUID())) {
 				$this->eventDispatcher->dispatchTyped(new UserChangedEvent($user, 'displayName', $newDisplayName, $oldDisplayName));
 			}
 		}


### PR DESCRIPTION
Closes #525 

This correctly propagates the display name value when it is changed and we get the new one while logging in.

This will also fix outdated display names (updated before this fix) on the next user login as the new name obtained from the IdP is checked against the one of the `user_oidc` backend and the one obtained from the user manager.

