### PR TITLE
Sync LDAP user with non-auto provisioning

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -461,6 +461,7 @@ class LoginController extends Controller {
 			// in case user is provisioned by user_ldap, userManager->search() triggers an ldap search which syncs the results
 			// so new users will be directly available even if they were not synced before this login attempt
 			$this->userManager->search($userId);
+			$this->ldapService->syncUser($userId);
 			// when auto provision is disabled, we assume the user has been created by another user backend (or manually)
 			$user = $this->userManager->get($userId);
 			if ($this->ldapService->isLdapDeletedUser($user)) {

--- a/lib/Service/LdapService.php
+++ b/lib/Service/LdapService.php
@@ -72,4 +72,20 @@ class LdapService {
 		// did we find the user in the LDAP deleted user list?
 		return $searchDisabledUser !== false;
 	}
+
+	/**
+	 * This triggers User_LDAP::getLDAPUserByLoginName which does a LDAP query with the login filter
+	 * so the user ID we got from the OIDC IdP should work as a login in LDAP (the login filter should use a matching attribute)
+	 * @param string $userId
+	 * @return void
+	 */
+	public function syncUser(string $userId): void {
+		try {
+			/** @var \OCA\User_LDAP\User_Proxy */
+			$ldapUserProxy = \OC::$server->get(\OCA\User_LDAP\User_Proxy::class);
+			$ldapUserProxy->loginName2UserName($userId);
+		} catch (QueryException $e) {
+			$this->logger->debug('\OCA\User_LDAP\User_Proxy class not found');
+		}
+	}
 }


### PR DESCRIPTION
With auto provisioning disabled, on login, we want the LDAP user list to be up to date. We already call `$this->userManager->search($userId)` but this triggers an LDAP query with a wildcard. As some LDAP attributes don't support wildcards, we need a better/safer way to make sure this specific user is synced to then be able to check if it exists locally with `$this->userManager->get($userId)`.

`OCA\User_LDAP\User_Proxy\loginName2UserName` is now called.

I still need to deploy a test environment to check this change is really effective.