### PR TITLE
Switch to debug logging for bearer token checks

### DIFF
--- a/lib/User/Backend.php
+++ b/lib/User/Backend.php
@@ -226,7 +226,7 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 		$headerToken = $this->request->getHeader(Application::OIDC_API_REQ_HEADER);
 		$headerToken = preg_replace('/^bearer\s+/i', '', $headerToken);
 		if ($headerToken === '') {
-			$this->logger->error('No Bearer token');
+			$this->logger->debug('No Bearer token');
 			return '';
 		}
 

--- a/lib/User/Backend.php
+++ b/lib/User/Backend.php
@@ -218,7 +218,7 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 	public function getCurrentUserId() {
 		$providers = $this->providerMapper->getProviders();
 		if (count($providers) === 0) {
-			$this->logger->error('no OIDC providers');
+			$this->logger->debug('no OIDC providers');
 			return '';
 		}
 


### PR DESCRIPTION
- Only log missing bearer token at debug level
- Log missing providers as debug

Otherwise this may produce unexpected errors in the log even if nothing is really wrong