### PR TITLE
Avoid empty string for scope when inserting/updating

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -260,11 +260,10 @@ class LoginController extends Controller {
 			}
 		}
 
-		$scope = $provider->getScope();
 		$data = [
 			'client_id' => $provider->getClientId(),
 			'response_type' => 'code',
-			'scope' => $scope === ' ' ? '' : $scope,
+			'scope' => trim($provider->getScope()),
 			'redirect_uri' => $this->urlGenerator->linkToRouteAbsolute(Application::APP_ID . '.login.code'),
 			'claims' => json_encode($claims),
 			'state' => $state,

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -260,10 +260,11 @@ class LoginController extends Controller {
 			}
 		}
 
+		$scope = $provider->getScope();
 		$data = [
 			'client_id' => $provider->getClientId(),
 			'response_type' => 'code',
-			'scope' => $provider->getScope(),
+			'scope' => $scope === ' ' ? '' : $scope,
 			'redirect_uri' => $this->urlGenerator->linkToRouteAbsolute(Application::APP_ID . '.login.code'),
 			'claims' => json_encode($claims),
 			'state' => $state,

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -59,7 +59,7 @@ class SettingsController extends Controller {
 	}
 
 	public function createProvider(string $identifier, string $clientId, string $clientSecret, string $discoveryEndpoint,
-								   array $settings = [], string $scope = "openid email profile"): JSONResponse {
+								   array $settings = [], string $scope = 'openid email profile'): JSONResponse {
 		if ($this->providerService->getProviderByIdentifier($identifier) !== null) {
 			return new JSONResponse(['message' => 'Provider with the given identifier already exists'], Http::STATUS_CONFLICT);
 		}
@@ -69,7 +69,7 @@ class SettingsController extends Controller {
 		$provider->setClientId($clientId);
 		$provider->setClientSecret($clientSecret);
 		$provider->setDiscoveryEndpoint($discoveryEndpoint);
-		$provider->setScope($scope);
+		$provider->setScope($scope ?: ' ');
 		$provider = $this->providerMapper->insert($provider);
 
 		$providerSettings = $this->providerService->setSettings($provider->getId(), $settings);
@@ -78,7 +78,7 @@ class SettingsController extends Controller {
 	}
 
 	public function updateProvider(int $providerId, string $identifier, string $clientId, string $discoveryEndpoint, string $clientSecret = null,
-								   array $settings = [], string $scope = "openid email profile"): JSONResponse {
+								   array $settings = [], string $scope = 'openid email profile'): JSONResponse {
 		$provider = $this->providerMapper->getProvider($providerId);
 
 		if ($this->providerService->getProviderByIdentifier($identifier) === null) {
@@ -91,7 +91,7 @@ class SettingsController extends Controller {
 			$provider->setClientSecret($clientSecret);
 		}
 		$provider->setDiscoveryEndpoint($discoveryEndpoint);
-		$provider->setScope($scope);
+		$provider->setScope($scope ?: ' ');
 		$provider = $this->providerMapper->update($provider);
 
 		$providerSettings = $this->providerService->setSettings($providerId, $settings);

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -69,7 +69,7 @@ class SettingsController extends Controller {
 		$provider->setClientId($clientId);
 		$provider->setClientSecret($clientSecret);
 		$provider->setDiscoveryEndpoint($discoveryEndpoint);
-		$provider->setScope($scope ?: ' ');
+		$provider->setScope($scope);
 		$provider = $this->providerMapper->insert($provider);
 
 		$providerSettings = $this->providerService->setSettings($provider->getId(), $settings);
@@ -91,7 +91,7 @@ class SettingsController extends Controller {
 			$provider->setClientSecret($clientSecret);
 		}
 		$provider->setDiscoveryEndpoint($discoveryEndpoint);
-		$provider->setScope($scope ?: ' ');
+		$provider->setScope($scope);
 		$provider = $this->providerMapper->update($provider);
 
 		$providerSettings = $this->providerService->setSettings($providerId, $settings);

--- a/lib/Db/Provider.php
+++ b/lib/Db/Provider.php
@@ -63,7 +63,7 @@ class Provider extends Entity implements \JsonSerializable {
 			'identifier' => $this->identifier,
 			'clientId' => $this->clientId,
 			'discoveryEndpoint' => $this->discoveryEndpoint,
-			'scope' => $this->scope,
+			'scope' => trim($this->scope),
 		];
 	}
 }

--- a/lib/Db/Provider.php
+++ b/lib/Db/Provider.php
@@ -36,7 +36,6 @@ use OCP\AppFramework\Db\Entity;
  * @method void setClientSecret(string $clientSecret)
  * @method string getDiscoveryEndpoint()
  * @method void setDiscoveryEndpoint(string $discoveryEndpoint)
- * @method string getScope()
  * @method void setScope(string $scope)
  */
 class Provider extends Entity implements \JsonSerializable {
@@ -55,6 +54,13 @@ class Provider extends Entity implements \JsonSerializable {
 
 	/** @var string */
 	protected $scope;
+
+	/**
+	 * @return string
+	 */
+	public function getScope(): string {
+		return $this->scope ?: ' ';
+	}
 
 	#[\ReturnTypeWillChange]
 	public function jsonSerialize() {

--- a/lib/Db/Provider.php
+++ b/lib/Db/Provider.php
@@ -69,7 +69,7 @@ class Provider extends Entity implements \JsonSerializable {
 			'identifier' => $this->identifier,
 			'clientId' => $this->clientId,
 			'discoveryEndpoint' => $this->discoveryEndpoint,
-			'scope' => trim($this->scope),
+			'scope' => trim($this->getScope()),
 		];
 	}
 }

--- a/lib/Db/ProviderMapper.php
+++ b/lib/Db/ProviderMapper.php
@@ -114,7 +114,7 @@ class ProviderMapper extends QBMapper {
 			$provider->setClientId($clientid);
 			$provider->setClientSecret($clientsecret);
 			$provider->setDiscoveryEndpoint($discoveryuri);
-			$provider->setScope($scope);
+			$provider->setScope($scope ?: ' ');
 			return $this->insert($provider);
 		} else {
 			if ($clientid !== null) {
@@ -126,7 +126,7 @@ class ProviderMapper extends QBMapper {
 			if ($discoveryuri !== null) {
 				$provider->setDiscoveryEndpoint($discoveryuri);
 			}
-			$provider->setScope($scope);
+			$provider->setScope($scope ?: ' ');
 			return $this->update($provider);
 		}
 	}

--- a/lib/Db/ProviderMapper.php
+++ b/lib/Db/ProviderMapper.php
@@ -114,7 +114,7 @@ class ProviderMapper extends QBMapper {
 			$provider->setClientId($clientid);
 			$provider->setClientSecret($clientsecret);
 			$provider->setDiscoveryEndpoint($discoveryuri);
-			$provider->setScope($scope ?: ' ');
+			$provider->setScope($scope);
 			return $this->insert($provider);
 		} else {
 			if ($clientid !== null) {
@@ -126,7 +126,7 @@ class ProviderMapper extends QBMapper {
 			if ($discoveryuri !== null) {
 				$provider->setDiscoveryEndpoint($discoveryuri);
 			}
-			$provider->setScope($scope ?: ' ');
+			$provider->setScope($scope);
 			return $this->update($provider);
 		}
 	}


### PR DESCRIPTION
Because oracle replaces it with null.

We could do it differently by allowing null values for the scope column. Any preferred option?