### PR TITLE
Include exception in error log when failing to get discovery info

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -281,7 +281,7 @@ class LoginController extends Controller {
 		try {
 			$discovery = $this->discoveryService->obtainDiscovery($provider);
 		} catch (\Exception $e) {
-			$this->logger->error('Could not reach the provider at URL ' . $provider->getDiscoveryEndpoint());
+			$this->logger->error('Could not reach the provider at URL ' . $provider->getDiscoveryEndpoint(), ['exception' => $e]);
 			$response = new TemplateResponse('', 'error', [
 				'errors' => [
 					['error' => 'Could not reach the OpenID Connect provider.'],


### PR DESCRIPTION
This makes it easier to debug discovery issues.