### PR TITLE
Fix CI, server master dropped Php 7.4 support

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4']
+        php-versions: ['8.0']
         databases: ['sqlite', 'mysql', 'pgsql']
         server-versions: ['master']
         include:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -19,11 +19,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.3', '7.4', "8.0", "8.1"]
+        php-versions: ['7.3', '7.4', '8.0', '8.1']
         databases: ['mysql']
         server-versions: ['stable21', 'stable22', 'stable23', 'stable24', 'stable25', 'master']
         exclude:
           - php-versions: 7.3
+            server-versions: master
+          - php-versions: 7.4
             server-versions: master
           - php-versions: 7.3
             server-versions: stable25


### PR DESCRIPTION
Use Php 8.0 for integration tests on server's master.