### PR TITLE
Fix id4me

### DIFF
--- a/lib/Helper/HttpClientHelper.php
+++ b/lib/Helper/HttpClientHelper.php
@@ -25,8 +25,10 @@ declare(strict_types=1);
 
 namespace OCA\UserOIDC\Helper;
 
-use Id4me\RP\HttpClient;
 use OCP\Http\Client\IClientService;
+
+require_once __DIR__ . '/../../vendor/autoload.php';
+use Id4me\RP\HttpClient;
 
 class HttpClientHelper implements HttpClient {
 


### PR DESCRIPTION
* Fix id4me-related imports
* Catch InvalidOpenIdDomainException exception to show nice error

I tried to import it via mozart but the `src` dir was not added in `lib/Vendor/Id4me`. I didn't wanna fight mozart so missing import are done via requiring composer's autoload file and then we directly import from `vendor`.