### PR TITLE
Do not use `IUserManager::getDisplayName()`

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@
 	<bugs>https://github.com/nextcloud/user_oidc/issues</bugs>
 	<repository>https://github.com/nextcloud/user_oidc</repository>
 	<dependencies>
-		<nextcloud min-version="21" max-version="26"/>
+		<nextcloud min-version="21" max-version="24"/>
 	</dependencies>
 	<settings>
 		<admin>OCA\UserOIDC\Settings\AdminSettings</admin>

--- a/lib/Service/ProvisioningService.php
+++ b/lib/Service/ProvisioningService.php
@@ -99,10 +99,8 @@ class ProvisioningService {
 				$backendUser->setDisplayName($newDisplayName);
 				$this->userMapper->update($backendUser);
 			}
-			// 2 reasons why we should update the display name: It does not match the one
-			// - of our backend
-			// - returned by the user manager (outdated one before the fix in https://github.com/nextcloud/user_oidc/pull/530)
-			if ($newDisplayName !== $oldDisplayName || $newDisplayName !== $this->userManager->getDisplayName($user->getUID())) {
+			// we should update the display name if it does not match the one of our backend
+			if ($newDisplayName !== $oldDisplayName) {
 				$this->eventDispatcher->dispatchTyped(new UserChangedEvent($user, 'displayName', $newDisplayName, $oldDisplayName));
 			}
 		}


### PR DESCRIPTION
refs #591

Set max NC version to 24.
Remove `IUserManager::getDisplayName()` usage.