### PR TITLE
25 <= nc version <= 27

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -19,7 +19,7 @@
 	<bugs>https://github.com/nextcloud/user_oidc/issues</bugs>
 	<repository>https://github.com/nextcloud/user_oidc</repository>
 	<dependencies>
-		<nextcloud min-version="21" max-version="26"/>
+		<nextcloud min-version="25" max-version="27"/>
 	</dependencies>
 	<settings>
 		<admin>OCA\UserOIDC\Settings\AdminSettings</admin>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
 	<name>OpenID Connect user backend</name>
 	<summary>Use an OpenID Connect backend to login to your Nextcloud</summary>
 	<description>Allows flexible configuration of an OIDC server as Nextcloud login user backend.</description>
-	<version>1.3.0</version>
+	<version>2.0.0</version>
 	<licence>agpl</licence>
 	<author>Roeland Jago Douma</author>
 	<author>Julius Härtl</author>


### PR DESCRIPTION
Main contains stuff that was introduced in Nextcloud 25.
While we're at it, bump max NC version to 27 and set the app's version to 2.0.0.
Releases for NC <= 24 can go on with 1.3.x.