### PR TITLE
Avoid using `IUserManager::getDisplayName` that was introduced in NC 25

### DIFF
--- a/lib/Service/ProvisioningService.php
+++ b/lib/Service/ProvisioningService.php
@@ -102,7 +102,7 @@ class ProvisioningService {
 			// 2 reasons why we should update the display name: It does not match the one
 			// - of our backend
 			// - returned by the user manager (outdated one before the fix in https://github.com/nextcloud/user_oidc/pull/530)
-			if ($newDisplayName !== $oldDisplayName || $newDisplayName !== $this->userManager->getDisplayName($user->getUID())) {
+			if ($newDisplayName !== $oldDisplayName || $newDisplayName !== $user->getDisplayName()) {
 				$this->eventDispatcher->dispatchTyped(new UserChangedEvent($user, 'displayName', $newDisplayName, $oldDisplayName));
 			}
 		}


### PR DESCRIPTION
Fix that keeps compat with NC <= 24