### PR TITLE
Don't include .nextcloudignore in app releases

### DIFF
--- a/.nextcloudignore
+++ b/.nextcloudignore
@@ -9,6 +9,7 @@
 /.travis.yml
 /.tx
 /.scrutinizer.yml
+/.nextcloudignore
 /babel.config.js
 /CONTRIBUTING.md
 /composer.json


### PR DESCRIPTION
Not a big deal but still cleaner :grin:.