### PR TITLE
Prepare 1.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.3.2
+
+### Fixed
+
+- fix Oracle database support by avoiding empty strings that are replaced with null @julien-nc [#563](https://github.com/nextcloud/user_oidc/pull/563)
+- use more recent Ubuntu image for PhpUnit tests as the old ones are not picked up by runners @julien-nc [#619](https://github.com/nextcloud/user_oidc/pull/619)
+- better error handling and throttling in Id4Me and login controllers @julien-nc [#615](https://github.com/nextcloud/user_oidc/pull/615) [#618](https://github.com/nextcloud/user_oidc/pull/618)
+
+### Other
+
+- show redirect URI to help configuring the client on the provider side @julien-nc [#598](https://github.com/nextcloud/user_oidc/pull/598)
+- add Nextcloud 27 support @julien-nc [#616](https://github.com/nextcloud/user_oidc/pull/616)
+
 ## 1.3.1
 
 ### Fixed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
 	<name>OpenID Connect user backend</name>
 	<summary>Use an OpenID Connect backend to login to your Nextcloud</summary>
 	<description>Allows flexible configuration of an OIDC server as Nextcloud login user backend.</description>
-	<version>1.3.1</version>
+	<version>1.3.2</version>
 	<licence>agpl</licence>
 	<author>Roeland Jago Douma</author>
 	<author>Julius Härtl</author>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "user_oidc",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "user_oidc",
-			"version": "1.3.1",
+			"version": "1.3.2",
 			"license": "AGPL-3.0-or-later",
 			"dependencies": {
 				"@nextcloud/axios": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "user_oidc",
 	"description": "OIDC connect user backend for Nextcloud",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"author": "Roeland Jago Douma <roeland@famdouma.nl>",
 	"repository": {
 		"url": "https://github.com/nextcloud/user_oidc",


### PR DESCRIPTION
## 1.3.2

### Fixed

- fix Oracle database support by avoiding empty strings that are replaced with null @julien-nc [#563](https://github.com/nextcloud/user_oidc/pull/563)
- use more recent Ubuntu image for PhpUnit tests as the old ones are not picked up by runners @julien-nc [#619](https://github.com/nextcloud/user_oidc/pull/619)
- better error handling and throttling in Id4Me and login controllers @julien-nc [#615](https://github.com/nextcloud/user_oidc/pull/615) [#618](https://github.com/nextcloud/user_oidc/pull/618)

### Other

- show redirect URI to help configuring the client on the provider side @julien-nc [#598](https://github.com/nextcloud/user_oidc/pull/598)
- add Nextcloud 27 support @julien-nc [#616](https://github.com/nextcloud/user_oidc/pull/616)