### PR TITLE
Set displayName for simple group lists

### DIFF
--- a/lib/Service/ProvisioningService.php
+++ b/lib/Service/ProvisioningService.php
@@ -333,7 +333,7 @@ class ProvisioningService {
 					$group = $v;
 				} elseif (is_string($v)) {
 					// Handle array of strings, e.g. ["group1", "group2", ...]
-					$group = (object)['gid' => $v];
+					$group = (object)['gid' => $v, 'displayName' => $v];
 				} else {
 					continue;
 				}


### PR DESCRIPTION
Thus far, all groups created from a simple "groups" list that only contains the names of the groups get converted into their IDs, making for a very unintuitive UX.

This tiny modification sets the `displayName` value for the groups to the same name as the source groups, thus preserving the group names while not touching the (generated) group IDs.