### PR TITLE
Prepare 1.3.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.3.3
+
+### Changed
+
+- Add issuer and azp validation, improve audience validation @julien-nc [#642](https://github.com/nextcloud/user_oidc/pull/642)
+- Encrypt stored oidc provider client secrets and id4me client secrets @julien-nc [#636](https://github.com/nextcloud/user_oidc/pull/636)
+
 ## 1.3.2
 
 ### Fixed


### PR DESCRIPTION
## 1.3.3

### Changed

- Add issuer and azp validation, improve audience validation @julien-nc [#642](https://github.com/nextcloud/user_oidc/pull/642)
- Encrypt stored oidc provider client secrets and id4me client secrets @julien-nc [#636](https://github.com/nextcloud/user_oidc/pull/636)