### PR TITLE
fix: Disable password confirmation for SSO

### DIFF
--- a/lib/Controller/Id4meController.php
+++ b/lib/Controller/Id4meController.php
@@ -295,6 +295,9 @@ class Id4meController extends BaseOidcController {
 		$this->userSession->completeLogin($user, ['loginName' => $user->getUID(), 'password' => '']);
 		$this->userSession->createSessionToken($this->request, $user->getUID(), $user->getUID());
 
+		// Set last password confirm to the future as we don't have passwords to confirm against with SSO
+		$this->session->set('last-password-confirm', strtotime('+4 year', time()));
+
 		return new RedirectResponse(\OC_Util::getDefaultPageUrl());
 	}
 }

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -502,6 +502,9 @@ class LoginController extends BaseOidcController {
 		$this->userSession->createSessionToken($this->request, $user->getUID(), $user->getUID());
 		$this->userSession->createRememberMeToken($user);
 
+		// Set last password confirm to the future as we don't have passwords to confirm against with SSO
+		$this->session->set('last-password-confirm', strtotime('+4 year', time()));
+
 		// for backchannel logout
 		try {
 			$authToken = $this->authTokenProvider->getToken($this->session->getId());


### PR DESCRIPTION
Similar behaviour as the user_saml app to avoid asking for password confirmation for SSO where we don't have a password to validate against.

Fixes #468 