### PR TITLE
Telekom bearer token: additional secret

### DIFF
--- a/lib/Db/Provider.php
+++ b/lib/Db/Provider.php
@@ -55,6 +55,9 @@ class Provider extends Entity implements \JsonSerializable {
 	/** @var string */
 	protected $scope;
 
+	/** @var string */
+	protected $bearerSecret;
+
 	/**
 	 * @return string
 	 */

--- a/lib/Db/ProviderMapper.php
+++ b/lib/Db/ProviderMapper.php
@@ -98,7 +98,7 @@ class ProviderMapper extends QBMapper {
 	 */
 	public function createOrUpdateProvider(string $identifier, string $clientid = null,
 									string $clientsecret = null, string $discoveryuri = null,
-									string $scope = 'openid email profile') {
+									string $scope = 'openid email profile', string $bearersecret = null) {
 		try {
 			$provider = $this->findProviderByIdentifier($identifier);
 		} catch (DoesNotExistException $eNotExist) {
@@ -115,6 +115,7 @@ class ProviderMapper extends QBMapper {
 			$provider->setClientSecret($clientsecret);
 			$provider->setDiscoveryEndpoint($discoveryuri);
 			$provider->setScope($scope);
+			$provider->setBearerSecret($bearersecret ?? '');
 			return $this->insert($provider);
 		} else {
 			if ($clientid !== null) {
@@ -125,6 +126,9 @@ class ProviderMapper extends QBMapper {
 			}
 			if ($discoveryuri !== null) {
 				$provider->setDiscoveryEndpoint($discoveryuri);
+			}
+			if ($bearerSecret !== null) {
+				$provider->setBearerSecret($bearersecret);
 			}
 			$provider->setScope($scope);
 			return $this->update($provider);

--- a/lib/Migration/Version00008Date20211114183344.php
+++ b/lib/Migration/Version00008Date20211114183344.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\UserOIDC\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version00008Date20211114183344 extends SimpleMigrationStep {
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$table = $schema->getTable('user_oidc_providers');
+		$table->addColumn('bearer_secret', 'string', [
+			'notnull' => true,
+			'length' => 64,
+		]);
+
+		return $schema;
+	}
+}


### PR DESCRIPTION
Telekom bearer token handling requires a secret different from the OpenID Connect client secret.
Field is added with the following properties:
- delivered as plain text, but internal token handling requires base64 encoding, so the field is base64 encoded/decoded internally
- the secret is encrypted in the same way as all other secret information in `user_oidc`.
- we keep the old DB update sequence

This PR only contains the DB and command line changes. UI changes are in separate PR