### PR TITLE
increased column length for id and secret

### DIFF
--- a/lib/Migration/Version010304Date20231121102449.php
+++ b/lib/Migration/Version010304Date20231121102449.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OCA\UserOIDC\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\IDBConnection;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+use OCP\Security\ICrypto;
+
+class Version010304Date20231121102449 extends SimpleMigrationStep {
+
+	/**
+	 * @var IDBConnection
+	 */
+	private $connection;
+	/**
+	 * @var ICrypto
+	 */
+	private $crypto;
+
+	public function __construct(
+		IDBConnection $connection,
+		ICrypto $crypto
+	) {
+		$this->connection = $connection;
+		$this->crypto = $crypto;
+	}
+
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options) {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		foreach (['user_oidc_providers', 'user_oidc_id4me'] as $tableName) {
+			if ($schema->hasTable($tableName)) {
+				$table = $schema->getTable($tableName);
+				if ($table->hasColumn('client_secret')) {
+					$column = $table->getColumn('client_secret');
+					$column->setLength(2048);
+					$column = $table->getColumn('client_id');
+					$column->setLength(2048);
+					$schemaChanged = true;
+				}
+			}
+		}
+		if ($schemaChanged) {
+			return $schema;
+		}
+		return null;
+	}
+}

--- a/lib/Migration/Version010304Date20231121102449.php
+++ b/lib/Migration/Version010304Date20231121102449.php
@@ -34,6 +34,7 @@ class Version010304Date20231121102449 extends SimpleMigrationStep {
 		/** @var ISchemaWrapper $schema */
 		$schema = $schemaClosure();
 
+		$schemaChanged = false;
 		foreach (['user_oidc_providers', 'user_oidc_id4me'] as $tableName) {
 			if ($schema->hasTable($tableName)) {
 				$table = $schema->getTable($tableName);

--- a/lib/Migration/Version010304Date20231121102449.php
+++ b/lib/Migration/Version010304Date20231121102449.php
@@ -40,6 +40,9 @@ class Version010304Date20231121102449 extends SimpleMigrationStep {
 				if ($table->hasColumn('client_secret')) {
 					$column = $table->getColumn('client_secret');
 					$column->setLength(2048);
+					$schemaChanged = true;
+				}
+				if ($table->hasColumn('client_id')) {
 					$column = $table->getColumn('client_id');
 					$column->setLength(2048);
 					$schemaChanged = true;


### PR DESCRIPTION
closes #405
Increased column limit to 2048 for client_secret and client_id as there is no specified max length in https://www.rfc-editor.org/rfc/rfc6749