### PR TITLE
fix(login): user get null check

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -503,7 +503,7 @@ class LoginController extends BaseOidcController {
 			$this->ldapService->syncUser($userId);
 			// when auto provision is disabled, we assume the user has been created by another user backend (or manually)
 			$user = $this->userManager->get($userId);
-			if ($this->ldapService->isLdapDeletedUser($user)) {
+			if ($user !== null && $this->ldapService->isLdapDeletedUser($user)) {
 				$user = null;
 			}
 		}


### PR DESCRIPTION
```
Nachricht: OCA\UserOIDC\Service\LdapService::isLdapDeletedUser(): Argument #1 ($user) must be of type OCP\IUser, null given, called in /var/www/nextcloud/apps/user_oidc/lib/Controller/LoginController.php on line 506 in file '/var/www/nextcloud/apps/user_oidc/lib/Service/LdapService.php' line 47
Datei: /var/www/nextcloud/lib/private/AppFramework/Http/Dispatcher.php
Zeile: 169

Trace
#0 /var/www/nextcloud/lib/private/AppFramework/App.php(183): OC\AppFramework\Http\Dispatcher->dispatch(Object(OCA\UserOIDC\Controller\LoginController), 'code')
#1 /var/www/nextcloud/lib/private/Route/Router.php(315): OC\AppFramework\App::main('OCA\\UserOIDC\\Co...', 'code', Object(OC\AppFramework\DependencyInjection\DIContainer), Array)
#2 /var/www/nextcloud/lib/base.php(1068): OC\Route\Router->match('/apps/user_oidc...')
#3 /var/www/nextcloud/index.php(38): OC::handleRequest()
#4 {main}

```