### PR TITLE
Fix first login check during bearer token auth

### DIFF
--- a/lib/User/Backend.php
+++ b/lib/User/Backend.php
@@ -363,7 +363,9 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 			}
 
 			// trigger any other initialization
-			\OC::$server->getEventDispatcher()->dispatch(IUser::class . '::firstLogin', new GenericEvent($user));
+			$this->eventDispatcher->dispatch(IUser::class . '::firstLogin', new GenericEvent($user));
+			// TODO add this when user_oidc min NC version is >= 28
+			// $this->eventDispatcher->dispatchTyped(new UserFirstTimeLoggedInEvent($user));
 		}
 		$user->updateLastLoginTimestamp();
 		return $firstLogin;


### PR DESCRIPTION
Authentication with bearer token was broken because `OC::$server->getEventDispatcher()` does not exist in NC >= 28.