### PR TITLE
Prepare v5.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 5.0.2 – 2024-03-18
+
+### Changed
+
+- Update npm packages
+
+### Fixed
+
+- Stop using missing OC::->getEventDispatcher method (dropped in NC 28) @julien-nc [#818](https://github.com/nextcloud/user_oidc/pull/818)
+
 ## 5.0.1 – 2024-02-28
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
 	<name>OpenID Connect user backend</name>
 	<summary>Use an OpenID Connect backend to login to your Nextcloud</summary>
 	<description>Allows flexible configuration of an OIDC server as Nextcloud login user backend.</description>
-	<version>5.0.1</version>
+	<version>5.0.2</version>
 	<licence>agpl</licence>
 	<author>Roeland Jago Douma</author>
 	<author>Julius Härtl</author>


### PR DESCRIPTION
### Changed

- Update npm packages

### Fixed

- Stop using missing OC::->getEventDispatcher method (dropped in NC 28) @julien-nc [#818](https://github.com/nextcloud/user_oidc/pull/818)