### PR TITLE
Perform a clean npm install when building release

### DIFF
--- a/krankerl.toml
+++ b/krankerl.toml
@@ -1,6 +1,6 @@
 [package]
 before_cmds = [
 	"composer install --no-dev -o",
-	"npm install",
+	"npm ci",
 	"npm run build",
 ]


### PR DESCRIPTION
To avoid installing more recent versions of the dependencies.