### PR TITLE
Fix setting avatar on login

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,9 +24,6 @@ jobs:
         include:
             - php-versions: 8.1
               databases: mysql
-              server-versions: stable25
-            - php-versions: 8.1
-              databases: mysql
               server-versions: stable26
             - php-versions: 8.1
               databases: mysql
@@ -34,6 +31,9 @@ jobs:
             - php-versions: 8.1
               databases: mysql
               server-versions: stable28
+            - php-versions: 8.1
+              databases: mysql
+              server-versions: stable29
             - php-versions: 8.1
               databases: mysql
               server-versions: master

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -19,12 +19,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4', '8.0', '8.1']
+        php-versions: ['7.4', '8.0', '8.1', '8.2']
         databases: ['mysql']
-        server-versions: ['stable25', 'stable26', 'stable27', 'stable28', 'master']
+        server-versions: ['stable26', 'stable27', 'stable28', 'stable29', 'master']
         exclude:
           - php-versions: 7.4
             server-versions: master
+          - php-versions: 7.4
+            server-versions: stable29
           - php-versions: 7.4
             server-versions: stable28
           - php-versions: 7.4
@@ -34,21 +36,9 @@ jobs:
           - php-versions: 8.0
             server-versions: master
         include:
-          - php-versions: 8.2
-            databases: mysql
-            server-versions: stable26
-          - php-versions: 8.2
-            databases: mysql
-            server-versions: stable27
-          - php-versions: 8.2
-            databases: mysql
-            server-versions: stable28
           - php-versions: 8.3
             databases: mysql
             server-versions: stable28
-          - php-versions: 8.2
-            databases: mysql
-            server-versions: master
           - php-versions: 8.3
             databases: mysql
             server-versions: master

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ To skip the confirmation, use `--force`.
 ***Warning***: be careful with the deletion of a provider because in some setup, this invalidates access to all
 NextCloud accounts associated with this provider.
 
+#### Avatar support
+
+The avatar attribute on your IdP side may contain a URL pointing to an image file or directly a base64 encoded image.
+The base64 should start with `data:image/png;base64,` or `data:image/jpeg;base64,`.
+The image should be in JPG or PNG format and have the same width and height.
+
 ### Disable default claims
 
 Even if you don't map any attribute for quota, display name, email or groups, this application will

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
 	<name>OpenID Connect user backend</name>
 	<summary>Use an OpenID Connect backend to login to your Nextcloud</summary>
 	<description>Allows flexible configuration of an OIDC server as Nextcloud login user backend.</description>
-	<version>5.0.3</version>
+	<version>6.0.0</version>
 	<licence>agpl</licence>
 	<author>Roeland Jago Douma</author>
 	<author>Julius Härtl</author>
@@ -19,7 +19,7 @@
 	<bugs>https://github.com/nextcloud/user_oidc/issues</bugs>
 	<repository>https://github.com/nextcloud/user_oidc</repository>
 	<dependencies>
-		<nextcloud min-version="25" max-version="30"/>
+		<nextcloud min-version="26" max-version="30"/>
 	</dependencies>
 	<settings>
 		<admin>OCA\UserOIDC\Settings\AdminSettings</admin>

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,8 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.24.0@462c80e31c34e58cc4f750c656be3927e80e550e">
-  <file src="lib/Service/ProvisioningService.php">
-    <RedundantCondition>
-      <code><![CDATA[isset($group->displayName)]]></code>
-    </RedundantCondition>
-  </file>
 </files>

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -1,3 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.24.0@462c80e31c34e58cc4f750c656be3927e80e550e">
+<files psalm-version="5.25.0@01a8eb06b9e9cc6cfb6a320bf9fb14331919d505">
+  <file src="lib/Service/ProvisioningService.php">
+    <MissingDependency>
+      <code><![CDATA[Image]]></code>
+    </MissingDependency>
+    <RedundantCondition>
+      <code><![CDATA[isset($group->displayName)]]></code>
+    </RedundantCondition>
+  </file>
 </files>

--- a/tests/unit/Service/ProvisioningServiceTest.php
+++ b/tests/unit/Service/ProvisioningServiceTest.php
@@ -8,6 +8,8 @@ use OCA\UserOIDC\Service\ProviderService;
 use OCA\UserOIDC\Service\ProvisioningService;
 use OCP\Accounts\IAccountManager;
 use OCP\EventDispatcher\IEventDispatcher;
+use OCP\Http\Client\IClientService;
+use OCP\IAvatarManager;
 use OCP\IGroup;
 use OCP\IGroupManager;
 use OCP\IUser;
@@ -44,6 +46,12 @@ class ProvisioningServiceTest extends TestCase {
 	/** @var IAccountManager | MockObject */
 	private $accountManager;
 
+	/** @var IClientService | MockObject */
+	private $clientService;
+
+	/** @var IAvatarManager | MockObject */
+	private $avatarManager;
+
 	public function setUp(): void {
 		parent::setUp();
 		$this->idService = $this->createMock(LocalIdService::class);
@@ -55,6 +63,8 @@ class ProvisioningServiceTest extends TestCase {
 		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
 		$this->logger = $this->createMock(LoggerInterface::class);
 		$this->accountManager = $this->createMock(IAccountManager::class);
+		$this->clientService = $this->createMock(IClientService::class);
+		$this->avatarManager = $this->createMock(IAvatarManager::class);
 
 		$this->provisioningService = new ProvisioningService(
 			$this->idService,
@@ -65,6 +75,8 @@ class ProvisioningServiceTest extends TestCase {
 			$this->eventDispatcher,
 			$this->logger,
 			$this->accountManager,
+			$this->clientService,
+			$this->avatarManager
 		);
 	}
 


### PR DESCRIPTION
* bump min NC version to 26 to make sure Php >= 8.0 and we get `str_starts_with`
* bump app version to 6.0.0 because we dropped compatibility with NC 25
* add support for avatar URL and base64
    * URL: content is downloaded and avatar is set on the fly
    * base64: support strings which begin with `data:image/png;base64,` and `data:image/jpeg;base64,`
* mention avatar support and details in the README

@juliushaertl What do you think about supporting URLs, in terms of security?

closes #835