### PR TITLE
Support missing end_session_endpoint in discovery during single logout

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -594,7 +594,7 @@ class LoginController extends BaseOidcController {
 
 				// Check if a custom end_session_endpoint is deposited otherwise use the default one provided by the openid-configuration
 				$discoveryData = $this->discoveryService->obtainDiscovery($provider);
-				$defaultEndSessionEndpoint = $discoveryData['end_session_endpoint'];
+				$defaultEndSessionEndpoint = $discoveryData['end_session_endpoint'] ?? null;
 				$customEndSessionEndpoint = $provider->getEndSessionEndpoint();
 				$endSessionEndpoint = $customEndSessionEndpoint ?: $defaultEndSessionEndpoint;
 


### PR DESCRIPTION
closes #847 
Avoid warnings when the Idp does not provide `end_session_endpoint` in the discovery.

@sebrhex Can you try to apply this change manually and check the warning log is not produced anymore?