### PR TITLE
fix(tests): Improve the stub so it's not confusing IDEs

### DIFF
--- a/tests/stubs/oc_core_command_base.php
+++ b/tests/stubs/oc_core_command_base.php
@@ -24,6 +24,9 @@ namespace OC\Core\Command {
 		public function setName(string $name) {
 		}
 
+		/**
+		 * @return $this
+		 */
 		public function addOption(string $name, $shortcut = null, int $mode = null, string $description = '', $default = null) {
 		}
 
@@ -36,6 +39,9 @@ namespace OC\Core\Command {
 		public function getHelper(string $name) {
 		}
 
+		/**
+		 * @return $this
+		 */
 		public function addArgument(string $name, int $mode = null, string $description = '', $default = null) {
 		}
 


### PR DESCRIPTION
### Steps
1. Checkout this app
2. Checkout another app that uses commands
3. Open the source code of a command
4. See that your IDE complains about using returned `void`s

Before | After
---|---
![Bildschirmfoto vom 2024-05-10 09-00-20](https://github.com/nextcloud/user_oidc/assets/213943/fada2f41-c1bc-41f7-a8ec-c3c95c716d5b) | ![Bildschirmfoto vom 2024-05-10 09-00-05](https://github.com/nextcloud/user_oidc/assets/213943/0787f85e-86ad-4549-8c04-8d3964af2f48)
