### PR TITLE
Add return annotation to setName in command stub

### DIFF
--- a/tests/stubs/oc_core_command_base.php
+++ b/tests/stubs/oc_core_command_base.php
@@ -21,7 +21,16 @@ namespace OC\Core\Command {
 		protected function configure() {
 		}
 
+		/**
+		 * @return $this
+		 */
 		public function setName(string $name) {
+		}
+
+		/**
+		 * @return $this
+		 */
+		public function setDescription(string $description) {
 		}
 
 		/**


### PR DESCRIPTION
PhpStorm still complained about setName, which makes sense. I wonder why it didn't for you @nickvergessen .