### PR TITLE
Add issuer, audience and azp checks in bearer token validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,16 @@ it is possible to disable the classic "self-encoded" validation:
 ],
 ```
 
+### Disable audience check in bearer token validation
+
+The `audience` and `azp` token claims will be checked when validating a bearer token for authenticated API requests.
+You can disable this check with this config value:
+``` php
+'user_oidc' => [
+    'selfencoded_bearer_validation_audience_check' => false,
+],
+```
+
 ## Building the app
 
 Requirements for building:

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -466,20 +466,12 @@ class LoginController extends BaseOidcController {
 			return $this->build403TemplateResponse($message, Http::STATUS_FORBIDDEN, ['invalid_audience' => $idTokenPayload->aud]);
 		}
 
-		// If the ID Token contains multiple audiences, the Client SHOULD verify that an azp Claim is present.
-		// If an azp (authorized party) Claim is present, the Client SHOULD verify that its client_id is the Claim Value.
-		if (is_array($idTokenPayload->aud) && count($idTokenPayload->aud) > 1) {
-			if (isset($idTokenPayload->azp)) {
-				if ($idTokenPayload->azp !== $provider->getClientId()) {
-					$this->logger->debug('This token is not for us, authorized party (azp) is different than the client ID');
-					$message = $this->l10n->t('The authorized party does not match ours');
-					return $this->build403TemplateResponse($message, Http::STATUS_FORBIDDEN, ['invalid_azp' => $idTokenPayload->azp]);
-				}
-			} else {
-				$this->logger->debug('Multiple audiences but no authorized party (azp) in the id token');
-				$message = $this->l10n->t('No authorized party');
-				return $this->build403TemplateResponse($message, Http::STATUS_FORBIDDEN, ['missing_azp']);
-			}
+		// ref https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
+		// If the azp claim is present, it should be the client ID
+		if (isset($idTokenPayload->azp) && $idTokenPayload->azp !== $provider->getClientId()) {
+			$this->logger->debug('This token is not for us, authorized party (azp) is different than the client ID');
+			$message = $this->l10n->t('The authorized party does not match ours');
+			return $this->build403TemplateResponse($message, Http::STATUS_FORBIDDEN, ['invalid_azp' => $idTokenPayload->azp]);
 		}
 
 		if (isset($idTokenPayload->nonce) && $idTokenPayload->nonce !== $this->session->get(self::NONCE)) {

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -455,7 +455,12 @@ class LoginController extends BaseOidcController {
 		}
 
 		// Verify audience
-		if (!($idTokenPayload->aud === $provider->getClientId() || in_array($provider->getClientId(), $idTokenPayload->aud, true))) {
+		$tokenAudience = $idTokenPayload->aud;
+		$providerClientId = $provider->getClientId();
+		if (
+			(is_string($tokenAudience) && $tokenAudience !== $providerClientId)
+				|| (is_array($tokenAudience) && !in_array($providerClientId, $tokenAudience, true))
+		) {
 			$this->logger->debug('This token is not for us');
 			$message = $this->l10n->t('The audience does not match ours');
 			return $this->build403TemplateResponse($message, Http::STATUS_FORBIDDEN, ['invalid_audience' => $idTokenPayload->aud]);

--- a/lib/User/Validator/SelfEncodedValidator.php
+++ b/lib/User/Validator/SelfEncodedValidator.php
@@ -99,18 +99,11 @@ class SelfEncodedValidator implements IBearerTokenValidator {
 				return null;
 			}
 
-			// If the ID Token contains multiple audiences, the Client SHOULD verify that an azp Claim is present.
-			// If an azp (authorized party) Claim is present, the Client SHOULD verify that its client_id is the Claim Value.
-			if (is_array($tokenAudience) && count($tokenAudience) > 1) {
-				if (isset($payload->azp)) {
-					if ($payload->azp !== $providerClientId) {
-						$this->logger->debug('This token is not for us, authorized party (azp) is different than the client ID');
-						return null;
-					}
-				} else {
-					$this->logger->debug('Multiple audiences but no authorized party (azp) in the id token');
-					return null;
-				}
+			// ref https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
+			// If the azp claim is present, it should be the client ID
+			if (isset($payload->azp) && $payload->azp !== $providerClientId) {
+				$this->logger->debug('This token is not for us, authorized party (azp) is different than the client ID');
+				return null;
 			}
 		}
 


### PR DESCRIPTION
The bearer token validation is less complete than the login controller one.

* add issuer, audience and azp (authorized party) checks in bearer token validator
* make it possible to disable bearer token audience check via config.php.

closes #856