### PR TITLE
Ignore keys using a P-521 curve

### DIFF
--- a/lib/Service/DiscoveryService.php
+++ b/lib/Service/DiscoveryService.php
@@ -156,6 +156,12 @@ class DiscoveryService {
 		}
 
 		foreach ($jwks['keys'] as $index => $key) {
+			// php-jwt fails in JWK::parseKeySet the keyset contains one key with P-521 curve
+			// see https://github.com/firebase/php-jwt/blob/main/src/JWK.php#L31
+			if (isset($key['crv']) && $key['crv'] === 'P-521') {
+				unset($jwks['keys'][$index]);
+			}
+
 			// Only fix the key being referred to in the JWT.
 			if ($jwtHeader['kid'] != $key['kid']) {
 				continue;


### PR DESCRIPTION
php-jwt dropped support for P-521 curve. Parsing a keyset which contains a key using this curve will now fail. We could either wait for php-jwt to do something about that. We could also remove this key from the keyset we receive from the IdP.

This is an attempt to fix #823 by removing any key using a P-521 curve from the discovered keys.