### PR TITLE
Allow to disable default quota, displayName, groups and email claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,20 @@ To skip the confirmation, use `--force`.
 ***Warning***: be careful with the deletion of a provider because in some setup, this invalidates access to all
 NextCloud accounts associated with this provider.
 
+### Disable default claims
+
+Even if you don't map any attribute for quota, display name, email or groups, this application will
+ask for the 'quota', 'name', 'email', 'groups' claims and map them to an attribute with the same name.
+
+To change this behaviour and disable the default claims, you can change this value in `config.php`:
+``` php
+'user_oidc' => [
+    'enable_default_claims' => false,
+],
+```
+
+When default claims are disabled, each claim will be asked for only if there is an attribute explicitely mapped
+in the OpenId client settings (in Nextcloud's admin settings).
 
 ### ID4me option
 ID4me is an application setting switch which is configurable as normal Nextcloud app setting:

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -244,29 +244,43 @@ class LoginController extends BaseOidcController {
 
 		// get attribute mapping settings
 		$uidAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_UID, 'sub');
-		$emailAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_EMAIL, 'email');
-		$displaynameAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_DISPLAYNAME, 'name');
-		$quotaAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_QUOTA, 'quota');
-		$groupsAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_GROUPS, 'groups');
 
 		$claims = [
 			// more details about requesting claims:
 			// https://openid.net/specs/openid-connect-core-1_0.html#IndividualClaimsRequests
-			'id_token' => [
-				// ['essential' => true] means it's mandatory but it won't trigger an error if it's not there
-				// null means we want it
-				$emailAttribute => null,
-				$displaynameAttribute => null,
-				$quotaAttribute => null,
-				$groupsAttribute => null,
-			],
-			'userinfo' => [
-				$emailAttribute => null,
-				$displaynameAttribute => null,
-				$quotaAttribute => null,
-				$groupsAttribute => null,
-			],
+			// ['essential' => true] means it's mandatory but it won't trigger an error if it's not there
+			// null means we want it
+			'id_token' => [],
+			'userinfo' => [],
 		];
+
+		// by default: default claims are ENABLED
+		// default claims are historically for quota, email, displayName and groups
+		$isDefaultClaimsEnabled = !isset($oidcSystemConfig['enable_default_claims'])
+			|| in_array($oidcSystemConfig['enable_default_claims'], [true, 'true', 1, '1'], true);
+		if ($isDefaultClaimsEnabled) {
+			// default claims for quota, email, displayName and groups is ENABLED
+			$emailAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_EMAIL, 'email');
+			$displaynameAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_DISPLAYNAME, 'name');
+			$quotaAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_QUOTA, 'quota');
+			$groupsAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_GROUPS, 'groups');
+			foreach ([$emailAttribute, $displaynameAttribute, $quotaAttribute, $groupsAttribute] as $claim) {
+				$claims['id_token'][$claim] = null;
+				$claims['userinfo'][$claim] = null;
+			}
+		} else {
+			// No default claim, we only set the claims if an attribute is mapped
+			$emailAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_EMAIL);
+			$displaynameAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_DISPLAYNAME);
+			$quotaAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_QUOTA);
+			$groupsAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_GROUPS);
+			foreach ([$emailAttribute, $displaynameAttribute, $quotaAttribute, $groupsAttribute] as $claim) {
+				if ($claim !== '') {
+					$claims['id_token'][$claim] = null;
+					$claims['userinfo'][$claim] = null;
+				}
+			}
+		}
 
 		if ($uidAttribute !== 'sub') {
 			$claims['id_token'][$uidAttribute] = ['essential' => true];

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -256,8 +256,7 @@ class LoginController extends BaseOidcController {
 
 		// by default: default claims are ENABLED
 		// default claims are historically for quota, email, displayName and groups
-		$isDefaultClaimsEnabled = !isset($oidcSystemConfig['enable_default_claims'])
-			|| in_array($oidcSystemConfig['enable_default_claims'], [true, 'true', 1, '1'], true);
+		$isDefaultClaimsEnabled = !isset($oidcSystemConfig['enable_default_claims']) || $oidcSystemConfig['enable_default_claims'] !== false;
 		if ($isDefaultClaimsEnabled) {
 			// default claims for quota, email, displayName and groups is ENABLED
 			$emailAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_EMAIL, 'email');


### PR DESCRIPTION
Even if an Oidc client is configured with no attribute mapping for quota, email, displayName or groups, those claims are included by default.

This allows using a global config switch (in config.php) to disable those default claims and only use them if a mapping is set in the client's settings (user_oidc's admin settings).

Default claims are enabled by default (to not break existing setups).