### PR TITLE
Fix biography attr being used to set the account gender

### DIFF
--- a/lib/Service/ProvisioningService.php
+++ b/lib/Service/ProvisioningService.php
@@ -299,7 +299,7 @@ class ProvisioningService {
 		}
 
 		// Update the gender
-		$event = new AttributeMappedEvent(ProviderService::SETTING_MAPPING_BIOGRAPHY, $idTokenPayload, $biography);
+		$event = new AttributeMappedEvent(ProviderService::SETTING_MAPPING_GENDER, $idTokenPayload, $gender);
 		$this->eventDispatcher->dispatchTyped($event);
 		$this->logger->debug('Gender mapping event dispatched');
 		if ($event->hasValue()) {


### PR DESCRIPTION
The biography token attr value was used to set the gender account prop, causing issues when there was no gender but a biography set in the token.

closes #887

cc @skyeBreach