### PR TITLE
Fix #349 Support for client_secret_basic only token_endpoint_auth_method

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -415,7 +415,7 @@ class LoginController extends BaseOidcController {
 
 			$headers = [];
 			$tokenEndpointAuthMethod = 'client_secret_basic';
-			// Use POST only if client_secret_basic is not available
+			// Use POST only if client_secret_basic is not available as supported by the endpoint
 			if (array_key_exists('token_endpoint_auth_methods_supported', $discovery) &&
 				is_array($discovery['token_endpoint_auth_methods_supported']) &&
 				in_array('client_secret_post', $discovery['token_endpoint_auth_methods_supported']) &&
@@ -424,9 +424,8 @@ class LoginController extends BaseOidcController {
 			}
 
 			if ($tokenEndpointAuthMethod == 'client_secret_basic') {
-				$credentials = base64_encode($provider->getClientId() . ':' . $providerClientSecret);
 				$headers = [
-					'Authorization' => 'Basic ' . $credentials,
+					'Authorization' => 'Basic ' . base64_encode($provider->getClientId() . ':' . $providerClientSecret),
 					'Content-Type' => 'application/x-www-form-urlencoded',
 				];
 			} else {


### PR DESCRIPTION
The OIDC provider I'm using only supports client_secret_basic in their token_endpoint_auth_methods_supported.
This is coded in a way that it only attempts to use the header based auth when ONLY client_secret_basic is provided in discovery "token_endpoint_auth_methods_supported".