### PR TITLE
Make audience and azp checks optional 

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,13 +195,16 @@ it is possible to disable the classic "self-encoded" validation:
 ],
 ```
 
-### Disable audience check in bearer token validation
+### Disable audience and azp checks
 
-The `audience` and `azp` token claims will be checked when validating a bearer token for authenticated API requests.
-You can disable this check with this config value:
+The `audience` and `azp` token claims will be checked when validating a login or bearer ID token.
+You can disable these check with these config value (in config.php):
 ``` php
 'user_oidc' => [
+    'login_validation_audience_check' => false,
+    'login_validation_azp_check' => false,
     'selfencoded_bearer_validation_audience_check' => false,
+    'selfencoded_bearer_validation_azp_check' => false,
 ],
 ```
 

--- a/lib/User/Validator/SelfEncodedValidator.php
+++ b/lib/User/Validator/SelfEncodedValidator.php
@@ -98,7 +98,11 @@ class SelfEncodedValidator implements IBearerTokenValidator {
 				$this->logger->debug('This token is not for us, the audience does not match the client ID');
 				return null;
 			}
+		}
 
+		$checkAzp = !isset($oidcSystemConfig['selfencoded_bearer_validation_azp_check'])
+			|| !in_array($oidcSystemConfig['selfencoded_bearer_validation_azp_check'], [false, 'false', 0, '0'], true);
+		if ($checkAzp) {
 			// ref https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
 			// If the azp claim is present, it should be the client ID
 			if (isset($payload->azp) && $payload->azp !== $providerClientId) {


### PR DESCRIPTION
Make audience and azp checks optional when logging in or validating a bearer token.

refs #856
closes #918

@col-panic Until the azp check is clarified, I think it's enough to be able to disable aud and azp checks independently during login or NC API requests bearer token validation. Wdyt?