### PR TITLE
Fix/947/empty address

### DIFF
--- a/lib/Service/ProvisioningService.php
+++ b/lib/Service/ProvisioningService.php
@@ -205,6 +205,8 @@ class ProvisioningService {
 					$addressArray[$regionAttribute] ?? '',
 					$addressArray[$countryAttribute] ?? '',
 				];
+			} else {
+				$address = null;
 			}
 		} elseif ($street !== null || $postalcode !== null || $locality !== null || $region !== null || $country !== null) {
 			// Concatenate the address components


### PR DESCRIPTION
closes #947

Fix address mapping when the token attribute is an object that can't be parsed as an array.

cc @isdnfan