### PR TITLE
Backchannel logout endpoint should only return 200 or 400

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -671,7 +671,6 @@ class LoginController extends BaseOidcController {
 	 *
 	 * @PublicPage
 	 * @NoCSRFRequired
-	 * @BruteForceProtection(action=userOidcBackchannelLogout)
 	 *
 	 * @param string $providerIdentifier
 	 * @param string $logout_token
@@ -788,23 +787,19 @@ class LoginController extends BaseOidcController {
 	 * @param string $error
 	 * @param string $description
 	 * @param array $throttleMetadata
-	 * @param bool|null $throttle
 	 * @return JSONResponse
 	 */
-	private function getBackchannelLogoutErrorResponse(string $error, string $description,
-		array $throttleMetadata = [], ?bool $throttle = null): JSONResponse {
+	private function getBackchannelLogoutErrorResponse(
+		string $error, string $description, array $throttleMetadata = [],
+	): JSONResponse {
 		$this->logger->debug('Backchannel logout error. ' . $error . ' ; ' . $description);
-		$response = new JSONResponse(
+		return new JSONResponse(
 			[
 				'error' => $error,
 				'error_description' => $description,
 			],
 			Http::STATUS_BAD_REQUEST,
 		);
-		if (($throttle === null && !$this->isDebugModeEnabled()) || $throttle) {
-			$response->throttle($throttleMetadata);
-		}
-		return $response;
 	}
 
 	private function toCodeChallenge(string $data): string {


### PR DESCRIPTION
According to https://openid.net/specs/openid-connect-backchannel-1_0.html#rfc.section.2.6 , the backchannel logout should only respond with 200 or 400 status code responses. With bruteforce protection, 429 can be returned.

Should we add a rate limit instead? What would be reasonable values?