### PR TITLE
Make the API controller an OCS controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,21 +232,18 @@ If you need the users to exist before they authenticate for the first time
 you can pre-provision them with the user_oidc API:
 
 ``` bash
-curl -H "ocs-apirequest: true" \
-  -u admin:admin \
-  https://my.nextcloud.org/ocs/v2.php/apps/user_oidc/api/v1/user \
-  -X POST \
-  -H "content-type: application/json" \
-  -d '{"providerId":2,"userId":"apicreate"}'
+curl -H "ocs-apirequest: true" -u admin:admin -X POST -H "content-type: application/json" \
+  -d '{"providerId":2,"userId":"new_user","displayName":"New User","email":"new@user.org","quota":"5GB"}' \
+  https://my.nextcloud.org/ocs/v2.php/apps/user_oidc/api/v1/user
 ```
+
+Only the `providerId` and `userId` parameters are mandatory.
 
 You can also delete users managed by user_oidc with this API endpoint:
 
 ``` bash
-curl -H "ocs-apirequest: true" \
-  -u admin:admin \
-  https://my.nextcloud.org/ocs/v2.php/apps/user_oidc/api/v1/user/USER_ID \
-  -X DELETE
+curl -H "ocs-apirequest: true" -u admin:admin -X DELETE
+  https://my.nextcloud.org/ocs/v2.php/apps/user_oidc/api/v1/user/USER_ID
 ```
 
 ### UserInfo request for Bearer token validation

--- a/README.md
+++ b/README.md
@@ -225,7 +225,29 @@ is enabled.
       ],
       ```
 
+### Pre-provisioning
 
+If you need the users to exist before they authenticate for the first time
+(because you want other users to be able to share files with them, for example)
+you can pre-provision them with the user_oidc API:
+
+``` bash
+curl -H "ocs-apirequest: true" \
+  -u admin:admin \
+  https://my.nextcloud.org/ocs/v2.php/apps/user_oidc/api/v1/user \
+  -X POST \
+  -H "content-type: application/json" \
+  -d '{"providerId":2,"userId":"apicreate"}'
+```
+
+You can also delete users managed by user_oidc with this API endpoint:
+
+``` bash
+curl -H "ocs-apirequest: true" \
+  -u admin:admin \
+  https://my.nextcloud.org/ocs/v2.php/apps/user_oidc/api/v1/user/USER_ID \
+  -X DELETE
+```
 
 ### UserInfo request for Bearer token validation
 

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -23,15 +23,16 @@ declare(strict_types=1);
  *
  */
 
+$requirements = [
+	'apiVersion' => '(v1)',
+];
+
 return [
 	'routes' => [
 		['name' => 'login#login', 'url' => '/login/{providerId}', 'verb' => 'GET'],
 		['name' => 'login#code', 'url' => '/code', 'verb' => 'GET'],
 		['name' => 'login#singleLogoutService', 'url' => '/sls', 'verb' => 'GET'],
 		['name' => 'login#backChannelLogout', 'url' => '/backchannel-logout/{providerIdentifier}', 'verb' => 'POST'],
-
-		['name' => 'api#createUser', 'url' => '/user', 'verb' => 'POST'],
-		['name' => 'api#deleteUser', 'url' => '/user/{userId}', 'verb' => 'DELETE'],
 
 		['name' => 'id4me#showLogin', 'url' => '/id4me', 'verb' => 'GET'],
 		['name' => 'id4me#login', 'url' => '/id4me', 'verb' => 'POST'],
@@ -43,5 +44,9 @@ return [
 		['name' => 'Settings#setID4ME', 'url' => '/provider/id4me', 'verb' => 'POST'],
 
 		['name' => 'Timezone#setTimezone', 'url' => '/config/timezone', 'verb' => 'POST'],
-	]
+	],
+	'ocs' => [
+		['name' => 'api#createUser', 'url' => '/api/{apiVersion}/user', 'verb' => 'POST', 'requirements' => $requirements],
+		['name' => 'api#deleteUser', 'url' => '/api/{apiVersion}/user/{userId}', 'verb' => 'DELETE', 'requirements' => $requirements],
+	],
 ];

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -34,6 +34,9 @@ return [
 		['name' => 'login#singleLogoutService', 'url' => '/sls', 'verb' => 'GET'],
 		['name' => 'login#backChannelLogout', 'url' => '/backchannel-logout/{providerIdentifier}', 'verb' => 'POST'],
 
+		['name' => 'api#createUser', 'url' => '/user', 'verb' => 'POST'],
+		['name' => 'api#deleteUser', 'url' => '/user/{userId}', 'verb' => 'DELETE'],
+
 		['name' => 'id4me#showLogin', 'url' => '/id4me', 'verb' => 'GET'],
 		['name' => 'id4me#login', 'url' => '/id4me', 'verb' => 'POST'],
 		['name' => 'id4me#code', 'url' => '/id4me/code', 'verb' => 'GET'],
@@ -46,7 +49,7 @@ return [
 		['name' => 'Timezone#setTimezone', 'url' => '/config/timezone', 'verb' => 'POST'],
 	],
 	'ocs' => [
-		['name' => 'api#createUser', 'url' => '/api/{apiVersion}/user', 'verb' => 'POST', 'requirements' => $requirements],
-		['name' => 'api#deleteUser', 'url' => '/api/{apiVersion}/user/{userId}', 'verb' => 'DELETE', 'requirements' => $requirements],
+		['name' => 'ocsApi#createUser', 'url' => '/api/{apiVersion}/user', 'verb' => 'POST', 'requirements' => $requirements],
+		['name' => 'ocsApi#deleteUser', 'url' => '/api/{apiVersion}/user/{userId}', 'verb' => 'DELETE', 'requirements' => $requirements],
 	],
 ];

--- a/composer.lock
+++ b/composer.lock
@@ -353,6 +353,52 @@
             "time": "2022-12-30T00:15:36+00:00"
         },
         {
+            "name": "kubawerlos/php-cs-fixer-custom-fixers",
+            "version": "v3.22.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers.git",
+                "reference": "8701394f0c7cd450ac4fa577d24589122c1d5d5e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kubawerlos/php-cs-fixer-custom-fixers/zipball/8701394f0c7cd450ac4fa577d24589122c1d5d5e",
+                "reference": "8701394f0c7cd450ac4fa577d24589122c1d5d5e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "ext-tokenizer": "*",
+                "friendsofphp/php-cs-fixer": "^3.61.1",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6.4 || ^10.5.29"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpCsFixerCustomFixers\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kuba Werłos",
+                    "email": "werlos@gmail.com"
+                }
+            ],
+            "description": "A set of custom fixers for PHP CS Fixer",
+            "support": {
+                "issues": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers/issues",
+                "source": "https://github.com/kubawerlos/php-cs-fixer-custom-fixers/tree/v3.22.0"
+            },
+            "time": "2024-08-16T20:44:35+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.12.0",
             "source": {
@@ -414,19 +460,20 @@
         },
         {
             "name": "nextcloud/coding-standard",
-            "version": "v1.2.1",
+            "version": "v1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud/coding-standard.git",
-                "reference": "cf5f18d989ec62fb4cdc7fc92a36baf34b3d829e"
+                "reference": "e88acb0df6217b808d1632286ddfec9267a102e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud/coding-standard/zipball/cf5f18d989ec62fb4cdc7fc92a36baf34b3d829e",
-                "reference": "cf5f18d989ec62fb4cdc7fc92a36baf34b3d829e",
+                "url": "https://api.github.com/repos/nextcloud/coding-standard/zipball/e88acb0df6217b808d1632286ddfec9267a102e4",
+                "reference": "e88acb0df6217b808d1632286ddfec9267a102e4",
                 "shasum": ""
             },
             "require": {
+                "kubawerlos/php-cs-fixer-custom-fixers": "^3.22",
                 "php": "^7.3|^8.0",
                 "php-cs-fixer/shim": "^3.17"
             },
@@ -449,9 +496,9 @@
             "description": "Nextcloud coding standards for the php cs fixer",
             "support": {
                 "issues": "https://github.com/nextcloud/coding-standard/issues",
-                "source": "https://github.com/nextcloud/coding-standard/tree/v1.2.1"
+                "source": "https://github.com/nextcloud/coding-standard/tree/v1.3.1"
             },
-            "time": "2024-02-01T14:54:37+00:00"
+            "time": "2024-09-19T09:07:10+00:00"
         },
         {
             "name": "nextcloud/ocp",

--- a/lib/Command/UpsertProvider.php
+++ b/lib/Command/UpsertProvider.php
@@ -154,7 +154,7 @@ class UpsertProvider extends Base {
 	public function __construct(
 		ProviderService $providerService,
 		ProviderMapper $providerMapper,
-		ICrypto $crypto
+		ICrypto $crypto,
 	) {
 		parent::__construct();
 		$this->providerService = $providerService;
@@ -242,7 +242,7 @@ class UpsertProvider extends Base {
 			// invalidate JWKS cache (even if it was just created)
 			$this->providerService->setSetting($provider->getId(), ProviderService::SETTING_JWKS_CACHE, '');
 			$this->providerService->setSetting($provider->getId(), ProviderService::SETTING_JWKS_CACHE_TIMESTAMP, '');
-		} catch (DoesNotExistException | MultipleObjectsReturnedException $e) {
+		} catch (DoesNotExistException|MultipleObjectsReturnedException $e) {
 			$output->writeln('<error>' . $e->getMessage() . '</error>');
 			return -1;
 		}

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -27,40 +27,26 @@ namespace OCA\UserOIDC\Controller;
 
 use OCA\UserOIDC\AppInfo\Application;
 use OCA\UserOIDC\Db\UserMapper;
-use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCSController;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotPermittedException;
 use OCP\IRequest;
 use OCP\IUserManager;
 
-class ApiController extends Controller {
-	/** @var UserMapper */
-	private $userMapper;
-
-	/** @var IUserManager */
-	private $userManager;
-	/**
-	 * @var IRootFolder
-	 */
-	private $root;
+class ApiController extends OCSController {
 
 	public function __construct(
 		IRequest $request,
-		IRootFolder $root,
-		UserMapper $userMapper,
-		IUserManager $userManager
+		private IRootFolder $root,
+		private UserMapper $userMapper,
+		private IUserManager $userManager
 	) {
 		parent::__construct(Application::APP_ID, $request);
-		$this->userMapper = $userMapper;
-		$this->userManager = $userManager;
-		$this->root = $root;
 	}
 
 	/**
-	 * @NoCSRFRequired
-	 *
 	 * @param int $providerId
 	 * @param string $userId
 	 * @param string|null $displayName
@@ -81,7 +67,7 @@ class ApiController extends Controller {
 		}
 
 		if ($email) {
-			$user->setEMailAddress($email);
+			$user->setSystemEMailAddress($email);
 		}
 
 		if ($quota) {
@@ -100,8 +86,6 @@ class ApiController extends Controller {
 	}
 
 	/**
-	 * @NoCSRFRequired
-	 *
 	 * @param string $userId
 	 * @return DataResponse
 	 */

--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -41,7 +41,7 @@ class ApiController extends OCSController {
 		IRequest $request,
 		private IRootFolder $root,
 		private UserMapper $userMapper,
-		private IUserManager $userManager
+		private IUserManager $userManager,
 	) {
 		parent::__construct(Application::APP_ID, $request);
 	}

--- a/lib/Controller/Id4meController.php
+++ b/lib/Controller/Id4meController.php
@@ -109,7 +109,7 @@ class Id4meController extends BaseOidcController {
 		Id4MeMapper $id4MeMapper,
 		ID4MeService $id4MeService,
 		LoggerInterface $logger,
-		ICrypto $crypto
+		ICrypto $crypto,
 	) {
 		parent::__construct($request, $config);
 
@@ -167,7 +167,7 @@ class Id4meController extends BaseOidcController {
 
 		try {
 			$authorityName = $this->id4me->discover($domain);
-		} catch (InvalidOpenIdDomainException | OpenIdDnsRecordNotFoundException $e) {
+		} catch (InvalidOpenIdDomainException|OpenIdDnsRecordNotFoundException $e) {
 			$message = $this->l10n->t('Invalid OpenID domain');
 			return $this->buildErrorTemplateResponse($message, Http::STATUS_BAD_REQUEST, ['invalid_openid_domain' => $domain]);
 		}
@@ -266,7 +266,7 @@ class Id4meController extends BaseOidcController {
 
 		try {
 			$id4Me = $this->id4MeMapper->findByIdentifier($authorityName);
-		} catch (DoesNotExistException | MultipleObjectsReturnedException $e) {
+		} catch (DoesNotExistException|MultipleObjectsReturnedException $e) {
 			$message = $this->l10n->t('Authority not found');
 			return $this->buildErrorTemplateResponse($message, Http::STATUS_BAD_REQUEST, ['authority_not_found' => $authorityName]);
 		}

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -150,7 +150,7 @@ class LoginController extends BaseOidcController {
 		ProvisioningService $provisioningService,
 		IL10N $l10n,
 		LoggerInterface $logger,
-		ICrypto $crypto
+		ICrypto $crypto,
 	) {
 		parent::__construct($request, $config);
 
@@ -234,7 +234,7 @@ class LoginController extends BaseOidcController {
 
 		try {
 			$provider = $this->providerMapper->getProvider($providerId);
-		} catch (DoesNotExistException | MultipleObjectsReturnedException $e) {
+		} catch (DoesNotExistException|MultipleObjectsReturnedException $e) {
 			$message = $this->l10n->t('There is not such OpenID Connect provider.');
 			return $this->buildErrorTemplateResponse($message, Http::STATUS_NOT_FOUND, ['provider_not_found' => $providerId]);
 		}
@@ -460,9 +460,9 @@ class LoginController extends BaseOidcController {
 					'headers' => $headers,
 				]
 			);
-		} catch (ClientException | ServerException $e) {
+		} catch (ClientException|ServerException $e) {
 			$response = $e->getResponse();
-			$body = (string) $response->getBody();
+			$body = (string)$response->getBody();
 			$responseBodyArray = json_decode($body, true);
 			if ($responseBodyArray !== null && isset($responseBodyArray['error'], $responseBodyArray['error_description'])) {
 				$this->logger->debug('Failed to contact the OIDC provider token endpoint', [
@@ -645,7 +645,7 @@ class LoginController extends BaseOidcController {
 			if ($providerId) {
 				try {
 					$provider = $this->providerMapper->getProvider((int)$providerId);
-				} catch (DoesNotExistException | MultipleObjectsReturnedException $e) {
+				} catch (DoesNotExistException|MultipleObjectsReturnedException $e) {
 					$message = $this->l10n->t('There is not such OpenID Connect provider.');
 					return $this->buildErrorTemplateResponse($message, Http::STATUS_NOT_FOUND, ['provider_id' => $providerId]);
 				}

--- a/lib/Controller/OcsApiController.php
+++ b/lib/Controller/OcsApiController.php
@@ -27,15 +27,15 @@ namespace OCA\UserOIDC\Controller;
 
 use OCA\UserOIDC\AppInfo\Application;
 use OCA\UserOIDC\Db\UserMapper;
-use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\OCSController;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotPermittedException;
 use OCP\IRequest;
 use OCP\IUserManager;
 
-class ApiController extends Controller {
+class OcsApiController extends OCSController {
 
 	public function __construct(
 		IRequest $request,
@@ -47,8 +47,6 @@ class ApiController extends Controller {
 	}
 
 	/**
-	 * @NoCSRFRequired
-	 *
 	 * @param int $providerId
 	 * @param string $userId
 	 * @param string|null $displayName
@@ -88,8 +86,6 @@ class ApiController extends Controller {
 	}
 
 	/**
-	 * @NoCSRFRequired
-	 *
 	 * @param string $userId
 	 * @return DataResponse
 	 */

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -62,7 +62,7 @@ class SettingsController extends Controller {
 		ProviderService $providerService,
 		ICrypto $crypto,
 		IClientService $clientService,
-		LoggerInterface $logger
+		LoggerInterface $logger,
 	) {
 		parent::__construct(Application::APP_ID, $request);
 

--- a/lib/Listener/TimezoneHandlingListener.php
+++ b/lib/Listener/TimezoneHandlingListener.php
@@ -46,7 +46,7 @@ class TimezoneHandlingListener implements IEventListener {
 	public function __construct(
 		IUserSession $userSession,
 		ISession $session,
-		IConfig $config
+		IConfig $config,
 	) {
 		$this->userSession = $userSession;
 		$this->session = $session;

--- a/lib/Migration/Version010303Date20230602125945.php
+++ b/lib/Migration/Version010303Date20230602125945.php
@@ -46,7 +46,7 @@ class Version010303Date20230602125945 extends SimpleMigrationStep {
 
 	public function __construct(
 		IDBConnection $connection,
-		ICrypto $crypto
+		ICrypto $crypto,
 	) {
 		$this->connection = $connection;
 		$this->crypto = $crypto;

--- a/lib/Migration/Version010304Date20231121102449.php
+++ b/lib/Migration/Version010304Date20231121102449.php
@@ -24,7 +24,7 @@ class Version010304Date20231121102449 extends SimpleMigrationStep {
 
 	public function __construct(
 		IDBConnection $connection,
-		ICrypto $crypto
+		ICrypto $crypto,
 	) {
 		$this->connection = $connection;
 		$this->crypto = $crypto;

--- a/lib/Service/DiscoveryService.php
+++ b/lib/Service/DiscoveryService.php
@@ -95,7 +95,7 @@ class DiscoveryService {
 	 */
 	public function obtainJWK(Provider $provider, string $tokenToDecode): array {
 		$lastJwksRefresh = $this->providerService->getSetting($provider->getId(), ProviderService::SETTING_JWKS_CACHE_TIMESTAMP);
-		if ($lastJwksRefresh !== '' && (int) $lastJwksRefresh > time() - self::INVALIDATE_JWKS_CACHE_AFTER_SECONDS) {
+		if ($lastJwksRefresh !== '' && (int)$lastJwksRefresh > time() - self::INVALIDATE_JWKS_CACHE_AFTER_SECONDS) {
 			$rawJwks = $this->providerService->getSetting($provider->getId(), ProviderService::SETTING_JWKS_CACHE);
 			$rawJwks = json_decode($rawJwks, true);
 		} else {

--- a/lib/Service/OIDCService.php
+++ b/lib/Service/OIDCService.php
@@ -46,7 +46,7 @@ class OIDCService {
 		DiscoveryService $discoveryService,
 		LoggerInterface $logger,
 		IClientService $clientService,
-		ICrypto $crypto
+		ICrypto $crypto,
 	) {
 		$this->discoveryService = $discoveryService;
 		$this->logger = $logger;

--- a/lib/User/Backend.php
+++ b/lib/User/Backend.php
@@ -383,7 +383,7 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 	 */
 	private function provisionUser(
 		string $provisioningStrategyClass, Provider $provider, string $tokenUserId, string $headerToken,
-		?IUser $userFromOtherBackend
+		?IUser $userFromOtherBackend,
 	): ?IUser {
 		$provisioningStrategy = \OC::$server->get($provisioningStrategyClass);
 		return $provisioningStrategy->provisionUser($provider, $tokenUserId, $headerToken, $userFromOtherBackend);

--- a/lib/User/Validator/SelfEncodedValidator.php
+++ b/lib/User/Validator/SelfEncodedValidator.php
@@ -50,7 +50,7 @@ class SelfEncodedValidator implements IBearerTokenValidator {
 		DiscoveryService $discoveryService,
 		LoggerInterface $logger,
 		ITimeFactory $timeFactory,
-		IConfig $config
+		IConfig $config,
 	) {
 		$this->discoveryService = $discoveryService;
 		$this->logger = $logger;

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -22,8 +22,8 @@
 if (!defined('PHPUNIT_RUN')) {
 	define('PHPUNIT_RUN', 1);
 }
-require_once __DIR__.'/../../../lib/base.php';
-require_once __DIR__.'/../vendor/autoload.php';
+require_once __DIR__ . '/../../../lib/base.php';
+require_once __DIR__ . '/../vendor/autoload.php';
 
 \OC::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
 \OC_App::loadApp('user_oidc');

--- a/tests/integration/Test.php
+++ b/tests/integration/Test.php
@@ -130,7 +130,7 @@ class Test extends \Test\TestCase {
 		$form = $result->item(0);
 		$url = $form->getAttribute('action');
 		libxml_clear_errors();
-		return $this->client->post($url, ['form_params' => ['username' => $username, 'password' => $password, "credentialId" => '']]);
+		return $this->client->post($url, ['form_params' => ['username' => $username, 'password' => $password, 'credentialId' => '']]);
 	}
 
 	private function getUserHtmlData($response) {


### PR DESCRIPTION
* Keep the old API controller for backward compatibility
* Document the API in the README (we support NC 26 so we don't have the OpenAPI method attribute that appeared in 28)
* Make the API controller an OCS one
* Update nextcloud/coding-standard
* Run cs:fix