### PR TITLE
Prepare 6.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.1.1 – 2024-10-22
+
+### Fixed
+
+- Ensure providerClientId is declared when validating bearer tokens @artonge [#969](https://github.com/nextcloud/user_oidc/pull/969)
+
 ## 6.1.0 – 2024-10-15
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
 	<name>OpenID Connect user backend</name>
 	<summary>Use an OpenID Connect backend to login to your Nextcloud</summary>
 	<description>Allows flexible configuration of an OIDC server as Nextcloud login user backend.</description>
-	<version>6.1.0</version>
+	<version>6.1.1</version>
 	<licence>agpl</licence>
 	<author>Roeland Jago Douma</author>
 	<author>Julius Härtl</author>


### PR DESCRIPTION
### Fixed

- Ensure providerClientId is declared when validating bearer tokens @artonge [#969](https://github.com/nextcloud/user_oidc/pull/969)