### PR TITLE
Fixes Access forbidden - State token missing

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -209,7 +209,7 @@ class LoginController extends BaseOidcController {
 		return new RedirectResponse(
 			$redirectUrl === null
 				? null
-				: parse_url($redirectUrl, PHP_URL_PATH)
+				: join('?', array_filter(parse_url($redirectUrl), fn($k) => in_array($k, ['path', 'query']), ARRAY_FILTER_USE_KEY))
 		);
 	}
 

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -209,7 +209,7 @@ class LoginController extends BaseOidcController {
 		return new RedirectResponse(
 			$redirectUrl === null
 				? null
-				: join('?', array_filter(parse_url($redirectUrl), fn($k) => in_array($k, ['path', 'query']), ARRAY_FILTER_USE_KEY))
+				: join('?', array_filter(parse_url($redirectUrl), fn ($k) => in_array($k, ['path', 'query']), ARRAY_FILTER_USE_KEY))
 		);
 	}
 


### PR DESCRIPTION
This commit error Access forbidden - State token missing while trying to login using Nextcloud Desktop.

Commit 99f7b730e7911459de22898e431cfcf525f0393a ignored the query part of the redirectUrl, needed for Nextcloud Desktop to succeed authentication.