### PR TITLE
Implement token exchange mechanism for other apps

### DIFF
--- a/docs/token_exchange.md
+++ b/docs/token_exchange.md
@@ -1,3 +1,7 @@
+<!--
+  - SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
 ### Token exchange
 
 If your IdP supports token exchange, user_oidc can exchange the login token against another token.

--- a/docs/token_exchange.md
+++ b/docs/token_exchange.md
@@ -31,6 +31,11 @@ if (class_exists('OCA\UserOIDC\Event\ExchangedTokenRequestedEvent')) {
 		$this->eventDispatcher->dispatchTyped($event);
 	} catch (OCA\UserOIDC\Exception\TokenExchangeFailedException $e) {
 		$this->logger->debug('Failed to exchange token: ' . $e->getMessage());
+		$error = $e->getError();
+		$errorDescription = $e->getErrorDescription();
+		if ($error && $errorDescription) {
+			$this->logger->debug('Token exchange error response from the IdP: ' . $error . ' (' . $errorDescription . ')');
+		}
 	}
 	$token = $event->getToken();
 	if ($token === null) {

--- a/docs/token_exchange.md
+++ b/docs/token_exchange.md
@@ -1,0 +1,42 @@
+### Token exchange
+
+If your IdP supports token exchange, user_oidc can exchange the login token against another token.
+
+Keycloak supports token exchange if its "Preview" mode is enabled. See https://www.keycloak.org/securing-apps/token-exchange .
+
+:warning: Your IdP need to be configured accordingly. For example, Keycloak requires that token exchange is explicitely
+authorized for the target Oidc client.
+
+The type of token exchange that user_oidc can perform is "Internal token to internal token"
+(https://www.keycloak.org/securing-apps/token-exchange#_internal-token-to-internal-token-exchange).
+This means you can exchange a token delivered for an audience "A" for a token delivered for an audience "B".
+In other words, you can get a token of a different Oidc client than the one you configured in user_oidc.
+
+In short, you don't need the client ID and client secret of the target audience's client.
+Providing a token for the audience "A" (the login token) is enough to obtain a token for the audience "B".
+
+user_oidc is storing the login token in the user's Nextcloud session and takes care of refreshing it when needed.
+When another app wants to exchange the current login token for another one,
+it can dispatch the `OCA\UserOIDC\Event\ExchangedTokenRequestedEvent` event.
+The exchanged token is immediately stored in the event object itself.
+
+```php
+if (class_exists('OCA\UserOIDC\Event\ExchangedTokenRequestedEvent')) {
+	$event = new OCA\UserOIDC\Event\ExchangedTokenRequestedEvent('my_target_audience');
+	try {
+		$this->eventDispatcher->dispatchTyped($event);
+	} catch (OCA\UserOIDC\Exception\TokenExchangeFailedException $e) {
+		$this->logger->debug('Failed to exchange token: ' . $e->getMessage());
+	}
+	$token = $event->getToken();
+	if ($token === null) {
+		$this->logger->debug('ExchangedTokenRequestedEvent event has not been caught by user_oidc');
+	} else {
+		$this->logger->debug('Obtained a token that expires in ' . $token->getExpiresInFromNow());
+		// use the token
+		$accessToken = $token->getAccessToken();
+	}
+} else {
+	$this->logger->debug('The user_oidc app is not installed/available');
+}
+```

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -24,6 +24,7 @@ use OCA\UserOIDC\Service\DiscoveryService;
 use OCA\UserOIDC\Service\LdapService;
 use OCA\UserOIDC\Service\ProviderService;
 use OCA\UserOIDC\Service\ProvisioningService;
+use OCA\UserOIDC\Service\TokenService;
 use OCA\UserOIDC\Vendor\Firebase\JWT\JWT;
 use OCP\AppFramework\Db\DoesNotExistException;
 use OCP\AppFramework\Db\MultipleObjectsReturnedException;
@@ -77,6 +78,7 @@ class LoginController extends BaseOidcController {
 		private IL10N $l10n,
 		private LoggerInterface $logger,
 		private ICrypto $crypto,
+		private TokenService $tokenService,
 	) {
 		parent::__construct($request, $config);
 	}
@@ -507,6 +509,14 @@ class LoginController extends BaseOidcController {
 			$this->userSession->createSessionToken($this->request, $user->getUID(), $user->getUID());
 			$this->userSession->createRememberMeToken($user);
 		}
+
+		// store all token information for potential token exchange requests
+		$tokenData = array_merge(
+			$data,
+			['provider_id' => $providerId],
+		);
+		$this->tokenService->storeToken($tokenData);
+		$this->config->setUserValue($user->getUID(), Application::APP_ID, 'had_token_once', '1');
 
 		// Set last password confirm to the future as we don't have passwords to confirm against with SSO
 		$this->session->set('last-password-confirm', strtotime('+4 year', time()));

--- a/lib/Event/ExchangedTokenRequestedEvent.php
+++ b/lib/Event/ExchangedTokenRequestedEvent.php
@@ -1,0 +1,59 @@
+<?php
+/*
+ * @copyright Copyright (c) 2022 Julien Veyssier <eneiluj@posteo.net>
+ *
+ * @author Julien Veyssier <eneiluj@posteo.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+namespace OCA\UserOIDC\Event;
+
+use OCA\UserOIDC\Model\Token;
+use OCP\EventDispatcher\Event;
+
+/**
+ * This event is emitted with by other apps which need an exchanged token for another audience (another client ID)
+ */
+class ExchangedTokenRequestedEvent extends Event {
+
+	private ?Token $token = null;
+
+	public function __construct(
+		private string $targetAudience,
+	) {
+		parent::__construct();
+	}
+
+	public function getTargetAudience(): string {
+		return $this->targetAudience;
+	}
+
+	public function setTargetAudience(string $targetAudience): void {
+		$this->targetAudience = $targetAudience;
+	}
+
+	public function getToken(): ?Token {
+		return $this->token;
+	}
+
+	public function setToken(?Token $token): void {
+		$this->token = $token;
+	}
+}

--- a/lib/Event/ExchangedTokenRequestedEvent.php
+++ b/lib/Event/ExchangedTokenRequestedEvent.php
@@ -1,27 +1,10 @@
 <?php
-/*
- * @copyright Copyright (c) 2022 Julien Veyssier <eneiluj@posteo.net>
- *
- * @author Julien Veyssier <eneiluj@posteo.net>
- *
- * @license GNU AGPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- *
- */
 
 declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 
 namespace OCA\UserOIDC\Event;
 

--- a/lib/Exception/TokenExchangeFailedException.php
+++ b/lib/Exception/TokenExchangeFailedException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+namespace OCA\UserOIDC\Exception;
+
+use Exception;
+
+class TokenExchangeFailedException extends Exception {
+}

--- a/lib/Exception/TokenExchangeFailedException.php
+++ b/lib/Exception/TokenExchangeFailedException.php
@@ -11,4 +11,22 @@ namespace OCA\UserOIDC\Exception;
 use Exception;
 
 class TokenExchangeFailedException extends Exception {
+
+	public function __construct(
+		$message = '',
+		$code = 0,
+		$previous = null,
+		private ?string $error = null,
+		private ?string $errorDescription = null,
+	) {
+		parent::__construct($message, $code, $previous);
+	}
+
+	public function getError(): ?string {
+		return $this->error;
+	}
+
+	public function getErrorDescription(): ?string {
+		return $this->errorDescription;
+	}
 }

--- a/lib/Exception/TokenExchangeFailedException.php
+++ b/lib/Exception/TokenExchangeFailedException.php
@@ -1,10 +1,9 @@
 <?php
 
 declare(strict_types=1);
-
 /**
- * SPDX-FileCopyrightText: 2017 Nextcloud GmbH and Nextcloud contributors
- * SPDX-License-Identifier: AGPL-3.0-only
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 namespace OCA\UserOIDC\Exception;

--- a/lib/Listener/ExchangedTokenRequestedListener.php
+++ b/lib/Listener/ExchangedTokenRequestedListener.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @copyright Copyright (c) 2024 Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @author Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace OCA\UserOIDC\Listener;
+
+use OCA\UserOIDC\Event\ExchangedTokenRequestedEvent;
+use OCA\UserOIDC\Service\TokenService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @implements IEventListener<ExchangedTokenRequestedEvent|Event>
+ */
+class ExchangedTokenRequestedListener implements IEventListener {
+
+	public function __construct(
+		private IUserSession $userSession,
+		private TokenService $tokenService,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof ExchangedTokenRequestedEvent) {
+			return;
+		}
+
+		if (!$this->userSession->isLoggedIn()) {
+			return;
+		}
+
+		$targetAudience = $event->getTargetAudience();
+		$this->logger->debug('[TokenExchange Listener] received request for audience: ' . $targetAudience);
+		$token = $this->tokenService->getExchangedToken($targetAudience);
+		$event->setToken($token);
+	}
+}

--- a/lib/Listener/ExchangedTokenRequestedListener.php
+++ b/lib/Listener/ExchangedTokenRequestedListener.php
@@ -1,23 +1,9 @@
 <?php
+
+declare(strict_types=1);
 /**
- * @copyright Copyright (c) 2024 Julien Veyssier <julien-nc@posteo.net>
- *
- * @author Julien Veyssier <julien-nc@posteo.net>
- *
- * @license GNU AGPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 namespace OCA\UserOIDC\Listener;

--- a/lib/Model/Token.php
+++ b/lib/Model/Token.php
@@ -29,7 +29,7 @@ use JsonSerializable;
 
 class Token implements JsonSerializable {
 
-	private string $idToken;
+	private ?string $idToken;
 	private string $accessToken;
 	private int $expiresIn;
 	private int $refreshExpiresIn;
@@ -38,7 +38,7 @@ class Token implements JsonSerializable {
 	private ?int $providerId;
 
 	public function __construct(array $tokenData) {
-		$this->idToken = $tokenData['id_token'];
+		$this->idToken = $tokenData['id_token'] ?? null;
 		$this->accessToken = $tokenData['access_token'];
 		$this->expiresIn = $tokenData['expires_in'];
 		$this->refreshExpiresIn = $tokenData['refresh_expires_in'];
@@ -51,7 +51,7 @@ class Token implements JsonSerializable {
 		return $this->accessToken;
 	}
 
-	public function getIdToken(): string {
+	public function getIdToken(): ?string {
 		return $this->idToken;
 	}
 

--- a/lib/Model/Token.php
+++ b/lib/Model/Token.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * @copyright Copyright (c) 2021 Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @author Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+namespace OCA\UserOIDC\Model;
+
+use JsonSerializable;
+
+class Token implements JsonSerializable {
+
+	private string $idToken;
+	private string $accessToken;
+	private int $expiresIn;
+	private int $refreshExpiresIn;
+	private string $refreshToken;
+	private int $createdAt;
+	private ?int $providerId;
+
+	public function __construct(array $tokenData) {
+		$this->idToken = $tokenData['id_token'];
+		$this->accessToken = $tokenData['access_token'];
+		$this->expiresIn = $tokenData['expires_in'];
+		$this->refreshExpiresIn = $tokenData['refresh_expires_in'];
+		$this->refreshToken = $tokenData['refresh_token'];
+		$this->createdAt = $tokenData['created_at'] ?? time();
+		$this->providerId = $tokenData['provider_id'] ?? null;
+	}
+
+	public function getAccessToken(): string {
+		return $this->accessToken;
+	}
+
+	public function getIdToken(): string {
+		return $this->idToken;
+	}
+
+	public function getExpiresIn(): int {
+		return $this->expiresIn;
+	}
+
+	public function getExpiresInFromNow(): int {
+		$expiresAt = $this->createdAt + $this->expiresIn;
+		return $expiresAt - time();
+	}
+
+	public function getRefreshExpiresIn(): int {
+		return $this->refreshExpiresIn;
+	}
+
+	public function getRefreshExpiresInFromNow(): int {
+		$refreshExpiresAt = $this->createdAt + $this->refreshExpiresIn;
+		return $refreshExpiresAt - time();
+	}
+
+	public function getRefreshToken(): string {
+		return $this->refreshToken;
+	}
+
+	public function getProviderId(): ?int {
+		return $this->providerId;
+	}
+
+	public function isExpired(): bool {
+		return time() > ($this->createdAt + $this->expiresIn);
+	}
+
+	public function isExpiring(): bool {
+		return time() > ($this->createdAt + (int)($this->expiresIn / 2));
+	}
+
+	public function refreshIsExpired(): bool {
+		return time() > ($this->createdAt + $this->refreshExpiresIn);
+	}
+
+	public function refreshIsExpiring(): bool {
+		return time() > ($this->createdAt + (int)($this->refreshExpiresIn / 2));
+	}
+
+	public function getCreatedAt() {
+		return $this->createdAt;
+	}
+
+	public function jsonSerialize(): array {
+		return [
+			'id_token' => $this->idToken,
+			'access_token' => $this->accessToken,
+			'expires_in' => $this->expiresIn,
+			'refresh_expires_in' => $this->refreshExpiresIn,
+			'refresh_token' => $this->refreshToken,
+			'created_at' => $this->createdAt,
+			'provider_id' => $this->providerId,
+		];
+	}
+}

--- a/lib/Model/Token.php
+++ b/lib/Model/Token.php
@@ -1,27 +1,10 @@
 <?php
-/**
- * @copyright Copyright (c) 2021 Julien Veyssier <julien-nc@posteo.net>
- *
- * @author Julien Veyssier <julien-nc@posteo.net>
- *
- * @license GNU AGPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- *
- */
 
 declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 
 namespace OCA\UserOIDC\Model;
 

--- a/lib/Service/TokenService.php
+++ b/lib/Service/TokenService.php
@@ -1,0 +1,293 @@
+<?php
+/**
+ * @copyright Copyright (c) 2024 Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @author Julien Veyssier <julien-nc@posteo.net>
+ *
+ * @license GNU AGPL version 3 or any later version
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+declare(strict_types=1);
+
+namespace OCA\UserOIDC\Service;
+
+use OCA\UserOIDC\AppInfo\Application;
+use OCA\UserOIDC\Db\ProviderMapper;
+use OCA\UserOIDC\Exception\TokenExchangeFailedException;
+use OCA\UserOIDC\Model\Token;
+use OCA\UserOIDC\Vendor\Firebase\JWT\JWT;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\MultipleObjectsReturnedException;
+use OCP\Http\Client\IClient;
+use OCP\Http\Client\IClientService;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\ISession;
+use OCP\IURLGenerator;
+use OCP\IUserSession;
+use OCP\PreConditionNotMetException;
+use OCP\Security\ICrypto;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Token management service
+ * This is helpful to debug:
+ * tail -f data/nextcloud.log | grep "\[Token" | jq ".time,.message"
+ */
+class TokenService {
+
+	private const SESSION_TOKEN_KEY = Application::APP_ID . '-user-token';
+
+	private IClient $client;
+
+	public function __construct(
+		IClientService $clientService,
+		private ISession $session,
+		private IUserSession $userSession,
+		private IConfig $config,
+		private LoggerInterface $logger,
+		private ICrypto $crypto,
+		private IRequest $request,
+		private IURLGenerator $urlGenerator,
+		private DiscoveryService $discoveryService,
+		private ProviderMapper $providerMapper,
+	) {
+		$this->client = $clientService->newClient();
+	}
+
+	public function storeToken(array $tokenData): Token {
+		$token = new Token($tokenData);
+		$this->session->set(self::SESSION_TOKEN_KEY, json_encode($token, JSON_THROW_ON_ERROR));
+		$this->logger->debug('[TokenService] Store token');
+		return $token;
+	}
+
+	/**
+	 * Get the token stored in the session
+	 * If it has expired: try to refresh it
+	 *
+	 * @param bool $refreshIfExpired
+	 * @return Token|null Return a token only if it is valid or has been successfully refreshed
+	 * @throws \JsonException
+	 */
+	public function getToken(bool $refreshIfExpired = true): ?Token {
+		$sessionData = $this->session->get(self::SESSION_TOKEN_KEY);
+		if (!$sessionData) {
+			$this->logger->debug('[TokenService] getToken: no session data');
+			return null;
+		}
+
+		$token = new Token(json_decode($sessionData, true, 512, JSON_THROW_ON_ERROR));
+		// token is still valid
+		if (!$token->isExpired()) {
+			$this->logger->debug('[TokenService] getToken: token is still valid, it expires in ' . $token->getExpiresInFromNow() . ' and refresh expires in ' . $token->getRefreshExpiresInFromNow());
+			return $token;
+		}
+
+		// token has expired
+		// try to refresh the token if the refresh token is still valid
+		if ($refreshIfExpired && !$token->refreshIsExpired()) {
+			$this->logger->debug('[TokenService] getToken: token is expired and refresh token is still valid, refresh expires in ' . $token->getRefreshExpiresInFromNow());
+			return $this->refresh($token);
+		}
+
+		$this->logger->debug('[TokenService] getToken: return a token that has not been refreshed');
+		return $token;
+	}
+
+	/**
+	 * Check to make sure the login token is still valid
+	 *
+	 * @return void
+	 * @throws \JsonException
+	 * @throws PreConditionNotMetException
+	 */
+	public function checkLoginToken(): void {
+		$currentUser = $this->userSession->getUser();
+		if (!$this->userSession->isLoggedIn() || $currentUser === null) {
+			$this->logger->debug('[TokenService] checkLoginToken: user not logged in');
+			return;
+		}
+		if ($this->config->getUserValue($currentUser->getUID(), Application::APP_ID, 'had_token_once', '0') !== '1') {
+			$this->logger->debug('[TokenService] checkLoginToken: we never had a token before, check not needed');
+			return;
+		}
+
+		$token = $this->getToken();
+		if ($token === null) {
+			$this->logger->debug('[TokenService] checkLoginToken: token is null');
+			// if we don't have a token but we had one once,
+			// it means the session (where we store the token) has died
+			// so we need to reauthenticate
+			$this->logger->debug('[TokenService] checkLoginToken: token is null and user had_token_once -> logout');
+			$this->userSession->logout();
+		} elseif ($token->isExpired()) {
+			$this->logger->debug('[TokenService] checkLoginToken: token is still expired -> reauthenticate');
+			// if the token is not valid, it means we couldn't refresh it so we need to reauthenticate to get a fresh token
+			$this->reauthenticate($token->getProviderId());
+		}
+	}
+
+	public function reauthenticate(int $providerId) {
+		// Logout the user and redirect to the oidc login flow to gather a fresh token
+		$this->userSession->logout();
+		$redirectUrl = $this->urlGenerator->linkToRouteAbsolute(Application::APP_ID . '.login.login', [
+			'providerId' => $providerId,
+			'redirectUrl' => $this->request->getRequestUri(),
+		]);
+		header('Location: ' . $redirectUrl);
+		$this->logger->debug('[TokenService] reauthenticate', ['redirectUrl' => $redirectUrl]);
+		exit();
+	}
+
+	/**
+	 * @param Token $token
+	 * @return Token
+	 * @throws \JsonException
+	 * @throws DoesNotExistException
+	 * @throws MultipleObjectsReturnedException
+	 */
+	public function refresh(Token $token): Token {
+		$oidcProvider = $this->providerMapper->getProvider($token->getProviderId());
+		$discovery = $this->discoveryService->obtainDiscovery($oidcProvider);
+
+		try {
+			$clientSecret = $oidcProvider->getClientSecret();
+			if ($clientSecret !== '') {
+				try {
+					$clientSecret = $this->crypto->decrypt($clientSecret);
+				} catch (\Exception $e) {
+					$this->logger->error('[TokenService] Failed to decrypt oidc client secret to refresh the token');
+				}
+			}
+			$this->logger->debug('[TokenService] Refreshing the token: ' . $discovery['token_endpoint']);
+			$result = $this->client->post(
+				$discovery['token_endpoint'],
+				[
+					'body' => [
+						'client_id' => $oidcProvider->getClientId(),
+						'client_secret' => $clientSecret,
+						'grant_type' => 'refresh_token',
+						'refresh_token' => $token->getRefreshToken(),
+					],
+				]
+			);
+			$this->logger->debug('[TokenService] Token refresh request params', [
+				'client_id' => $oidcProvider->getClientId(),
+				// 'client_secret' => $clientSecret,
+				'grant_type' => 'refresh_token',
+				// 'refresh_token' => $token->getRefreshToken(),
+			]);
+			$body = $result->getBody();
+			$bodyArray = json_decode(trim($body), true, 512, JSON_THROW_ON_ERROR);
+			$this->logger->debug('[TokenService] ---- Refresh token success');
+			return $this->storeToken(
+				array_merge(
+					$bodyArray,
+					['provider_id' => $token->getProviderId()],
+				)
+			);
+		} catch (\Exception $e) {
+			$this->logger->error('[TokenService] Failed to refresh token ', ['exception' => $e]);
+			// Failed to refresh, return old token which will be retried or otherwise timeout if expired
+			return $token;
+		}
+	}
+
+	public function decodeIdToken(Token $token): array {
+		$provider = $this->providerMapper->getProvider($token->getProviderId());
+		$jwks = $this->discoveryService->obtainJWK($provider, $token->getIdToken());
+		JWT::$leeway = 60;
+		$idTokenObject = JWT::decode($token->getIdToken(), $jwks);
+		return json_decode(json_encode($idTokenObject), true);
+	}
+
+	/**
+	 * Exchange a token for another audience (client ID)
+	 *
+	 * @param string $targetAudience
+	 * @return Token
+	 * @throws DoesNotExistException
+	 * @throws MultipleObjectsReturnedException
+	 * @throws TokenExchangeFailedException
+	 * @throws \JsonException
+	 */
+	public function getExchangedToken(string $targetAudience): Token {
+		$loginToken = $this->getToken();
+		if ($loginToken === null) {
+			$this->logger->debug('[TokenService] Failed to exchange token, no login token found in the session');
+			throw new TokenExchangeFailedException('Failed to exchange token, no login token found in the session');
+		}
+		if ($loginToken->isExpired()) {
+			$this->logger->debug('[TokenService] Failed to exchange token, the login token is expired');
+			throw new TokenExchangeFailedException('Failed to exchange token, the login token is expired');
+		}
+		$oidcProvider = $this->providerMapper->getProvider($loginToken->getProviderId());
+		$discovery = $this->discoveryService->obtainDiscovery($oidcProvider);
+
+		try {
+			$clientSecret = $oidcProvider->getClientSecret();
+			if ($clientSecret !== '') {
+				try {
+					$clientSecret = $this->crypto->decrypt($clientSecret);
+				} catch (\Exception $e) {
+					$this->logger->error('[TokenService] Token Exchange: Failed to decrypt oidc client secret');
+				}
+			}
+			$this->logger->debug('[TokenService] Exchanging the token: ' . $discovery['token_endpoint']);
+			// more in https://www.keycloak.org/securing-apps/token-exchange
+			$result = $this->client->post(
+				$discovery['token_endpoint'],
+				[
+					'body' => [
+						'client_id' => $oidcProvider->getClientId(),
+						'client_secret' => $clientSecret,
+						'grant_type' => 'urn:ietf:params:oauth:grant-type:token-exchange',
+						'subject_token' => $loginToken->getAccessToken(),
+						'subject_token_type' => 'urn:ietf:params:oauth:token-type:access_token',
+						// can also be
+						// urn:ietf:params:oauth:token-type:access_token
+						// or urn:ietf:params:oauth:token-type:id_token
+						// this one will get us an access token and refresh token within the response
+						'requested_token_type' => 'urn:ietf:params:oauth:token-type:refresh_token',
+						'audience' => $targetAudience,
+					],
+				]
+			);
+			$this->logger->debug('[TokenService] Token exchange request params', [
+				'client_id' => $oidcProvider->getClientId(),
+				// 'client_secret' => $clientSecret,
+				'grant_type' => 'urn:ietf:params:oauth:grant-type:token-exchange',
+				// 'subject_token' => $loginToken->getAccessToken(),
+				'subject_token_type' => 'urn:ietf:params:oauth:token-type:access_token',
+				'requested_token_type' => 'urn:ietf:params:oauth:token-type:refresh_token',
+				'audience' => $targetAudience,
+			]);
+			$body = $result->getBody();
+			$bodyArray = json_decode(trim($body), true, 512, JSON_THROW_ON_ERROR);
+			$this->logger->debug('[TokenService] Token exchange success: "' . trim($body) . '"');
+			$tokenData = array_merge(
+				$bodyArray,
+				['provider_id' => $loginToken->getProviderId()],
+			);
+			return new Token($tokenData);
+		} catch (\Exception|\Throwable $e) {
+			$this->logger->error('[TokenService] Failed to exchange token ', ['exception' => $e]);
+			throw new TokenExchangeFailedException('Failed to exchange token, error in the exchange request', 0, $e);
+		}
+	}
+}

--- a/lib/Service/TokenService.php
+++ b/lib/Service/TokenService.php
@@ -1,27 +1,10 @@
 <?php
-/**
- * @copyright Copyright (c) 2024 Julien Veyssier <julien-nc@posteo.net>
- *
- * @author Julien Veyssier <julien-nc@posteo.net>
- *
- * @license GNU AGPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program. If not, see <http://www.gnu.org/licenses/>.
- *
- */
 
 declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
 
 namespace OCA\UserOIDC\Service;
 


### PR DESCRIPTION
Some integration apps (like integration_openproject) might need to make backend-to-backend requests to other services that use the same IdP as Nextcloud. If those services accept Oidc access tokens as a Bearer tokens for authentication, they might only accept the ones that were delivered for them (for their audience).

Token exchange is a mechanism to exchange a token that was delivered for an audience (for a specific Oidc client) against another token for another audience.

The idea here is to keep the token exchange logic in user_oidc so it saves the effort to reimplement it in all the apps that need it.

In short:
* The login token is stored in the Php session
* It is refreshed when needed
* If it can't be refreshed, we try to reauthenticate (which might be transparent for the user if the IdP session is still alive)
* We listen to the `ExchangedTokenRequestedEvent`
* We exchange the login token when receiving the event and place the result in the event

cc @individual-it @SagarGi