### PR TITLE
Adjust provisioning service to correctly update the display name on login

### DIFF
--- a/lib/Controller/ApiController.php
+++ b/lib/Controller/ApiController.php
@@ -78,7 +78,7 @@ class ApiController extends Controller {
 	 */
 	public function deleteUser(string $userId): DataResponse {
 		$user = $this->userManager->get($userId);
-		if (is_null($user) || $user->getBackendClassName() !== 'user_oidc') {
+		if (is_null($user) || $user->getBackendClassName() !== Application::APP_ID) {
 			return new DataResponse(['message' => 'User not found'], Http::STATUS_NOT_FOUND);
 		}
 

--- a/lib/Controller/OcsApiController.php
+++ b/lib/Controller/OcsApiController.php
@@ -74,7 +74,7 @@ class OcsApiController extends OCSController {
 	 */
 	public function deleteUser(string $userId): DataResponse {
 		$user = $this->userManager->get($userId);
-		if (is_null($user) || $user->getBackendClassName() !== 'user_oidc') {
+		if (is_null($user) || $user->getBackendClassName() !== Application::APP_ID) {
 			return new DataResponse(['message' => 'User not found'], Http::STATUS_NOT_FOUND);
 		}
 

--- a/lib/Service/ProvisioningService.php
+++ b/lib/Service/ProvisioningService.php
@@ -7,6 +7,7 @@
 
 namespace OCA\UserOIDC\Service;
 
+use OCA\UserOIDC\AppInfo\Application;
 use OCA\UserOIDC\Db\UserMapper;
 use OCA\UserOIDC\Event\AttributeMappedEvent;
 use OCP\Accounts\IAccountManager;
@@ -180,6 +181,12 @@ class ProvisioningService {
 				$oldDisplayName = $user->getDisplayName();
 				if ($newDisplayName !== $oldDisplayName) {
 					$user->setDisplayName($newDisplayName);
+					if ($user->getBackendClassName() === Application::APP_ID) {
+						$backendUser = $this->userMapper->getOrCreate($providerId, $user->getUID());
+						$backendUser->setDisplayName($newDisplayName);
+						$this->userMapper->update($backendUser);
+					}
+					$this->eventDispatcher->dispatchTyped(new UserChangedEvent($user, 'displayName', $newDisplayName, $oldDisplayName));
 				}
 			}
 		}


### PR DESCRIPTION
closes #920

On login, if the user already exists and is passed to the provisioning service, we acted like it was not from our backend but it can be (with soft and non-soft auto-provisioning).

The display name is now correctly updated.