### PR TITLE
Fix: update cache when discovery endpoint is changed

### DIFF
--- a/lib/Service/DiscoveryService.php
+++ b/lib/Service/DiscoveryService.php
@@ -46,7 +46,7 @@ class DiscoveryService {
 	}
 
 	public function obtainDiscovery(Provider $provider): array {
-		$cacheKey = 'discovery-' . $provider->getId();
+		$cacheKey = 'discovery-' . $provider->getDiscoveryEndpoint();
 		$cachedDiscovery = $this->cache->get($cacheKey);
 		if ($cachedDiscovery === null) {
 			$url = $provider->getDiscoveryEndpoint();


### PR DESCRIPTION
Before, endpoint discovery value was cached with ID as key. This keeps the old value in the cache if only the discovery endpoint of a provider is changed in the settings.