### PR TITLE
Add global scale (gss) support

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -588,7 +588,8 @@ class LoginController extends BaseOidcController {
 					$decoded = (array)JWT::decode($jwt, new Key($key, 'HS256'));
 
 					$providerId = $decoded['oidcProviderId'] ?? null;
-				} catch (\Exception) {
+				} catch (\Exception $e) {
+					$this->logger->debug('Failed to get the logout provider ID in the request from GSS', ['exception' => $e]);
 				}
 			} else {
 				$providerId = $this->session->get(self::PROVIDERID);

--- a/lib/Service/ProvisioningService.php
+++ b/lib/Service/ProvisioningService.php
@@ -19,6 +19,7 @@ use OCP\IAvatarManager;
 use OCP\IConfig;
 use OCP\IGroupManager;
 use OCP\Image;
+use OCP\ISession;
 use OCP\IUser;
 use OCP\IUserManager;
 use OCP\User\Events\UserChangedEvent;
@@ -39,6 +40,7 @@ class ProvisioningService {
 		private IClientService $clientService,
 		private IAvatarManager $avatarManager,
 		private IConfig $config,
+		private ISession $session,
 	) {
 	}
 
@@ -60,6 +62,9 @@ class ProvisioningService {
 	 * @throws Exception
 	 */
 	public function provisionUser(string $tokenUserId, int $providerId, object $idTokenPayload, ?IUser $existingLocalUser = null): ?IUser {
+		// user data potentially later used by globalsiteselector if user_oidc is used with global scale
+		$oidcGssUserData = get_object_vars($idTokenPayload);
+
 		// get name/email/quota information from the token itself
 		$emailAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_EMAIL, 'email');
 		$email = $idTokenPayload->{$emailAttribute} ?? null;
@@ -157,6 +162,7 @@ class ProvisioningService {
 		$this->eventDispatcher->dispatchTyped($event);
 		$this->logger->debug('Displayname mapping event dispatched');
 		if ($event->hasValue() && $event->getValue() !== null && $event->getValue() !== '') {
+			$oidcGssUserData[$displaynameAttribute] = $event->getValue();
 			$newDisplayName = $event->getValue();
 			if ($existingLocalUser === null) {
 				$oldDisplayName = $backendUser->getDisplayName();
@@ -183,6 +189,7 @@ class ProvisioningService {
 		$this->eventDispatcher->dispatchTyped($event);
 		$this->logger->debug('Email mapping event dispatched');
 		if ($event->hasValue() && $event->getValue() !== null && $event->getValue() !== '') {
+			$oidcGssUserData[$emailAttribute] = $event->getValue();
 			$user->setSystemEMailAddress($event->getValue());
 		}
 
@@ -191,12 +198,21 @@ class ProvisioningService {
 		$this->eventDispatcher->dispatchTyped($event);
 		$this->logger->debug('Quota mapping event dispatched');
 		if ($event->hasValue() && $event->getValue() !== null && $event->getValue() !== '') {
+			$oidcGssUserData[$quotaAttribute] = $event->getValue();
 			$user->setQuota($event->getValue());
 		}
 
 		// Update groups
 		if ($this->providerService->getSetting($providerId, ProviderService::SETTING_GROUP_PROVISIONING, '0') === '1') {
-			$this->provisionUserGroups($user, $providerId, $idTokenPayload);
+			$groups = $this->provisionUserGroups($user, $providerId, $idTokenPayload);
+			// for gss
+			if ($groups !== null) {
+				$groupIds = array_map(static function ($group) {
+					return $group->gid;
+				}, $groups);
+				$groupsAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_GROUPS, 'groups');
+				$oidcGssUserData[$groupsAttribute] = $groupIds;
+			}
 		}
 
 		// Update the phone number
@@ -317,6 +333,8 @@ class ProvisioningService {
 		if ($event->hasValue() && $event->getValue() !== null && $event->getValue() !== '') {
 			$account->setProperty('gender', $event->getValue(), $scope, '1', '');
 		}
+
+		$this->session->set('user_oidc.oidcUserData', $oidcGssUserData);
 
 		$this->accountManager->updateAccount($account);
 		return $user;
@@ -441,36 +459,40 @@ class ProvisioningService {
 		return null;
 	}
 
-	public function provisionUserGroups(IUser $user, int $providerId, object $idTokenPayload): void {
+	public function provisionUserGroups(IUser $user, int $providerId, object $idTokenPayload): ?array {
 		$groupsWhitelistRegex = $this->getGroupWhitelistRegex($providerId);
 
 		$syncGroups = $this->getSyncGroupsOfToken($providerId, $idTokenPayload);
 
-		if ($syncGroups !== null) {
+		if ($syncGroups === null) {
+			return null;
+		}
 
-			$userGroups = $this->groupManager->getUserGroups($user);
-			foreach ($userGroups as $group) {
-				if (!in_array($group->getGID(), array_column($syncGroups, 'gid'))) {
-					if ($groupsWhitelistRegex && !preg_match($groupsWhitelistRegex, $group->getGID())) {
-						continue;
-					}
-					$group->removeUser($user);
+		$userGroups = $this->groupManager->getUserGroups($user);
+		foreach ($userGroups as $group) {
+			if (!in_array($group->getGID(), array_column($syncGroups, 'gid'))) {
+				if ($groupsWhitelistRegex && !preg_match($groupsWhitelistRegex, $group->getGID())) {
+					continue;
 				}
+				$group->removeUser($user);
 			}
+		}
 
-			foreach ($syncGroups as $group) {
-				// Creates a new group or return the exiting one.
-				if ($newGroup = $this->groupManager->createGroup($group->gid)) {
-					// Adds the user to the group. Does nothing if user is already in the group.
-					$newGroup->addUser($user);
+		foreach ($syncGroups as $group) {
+			// Creates a new group or return the exiting one.
+			if ($newGroup = $this->groupManager->createGroup($group->gid)) {
+				// Adds the user to the group. Does nothing if user is already in the group.
+				$newGroup->addUser($user);
 
-					if (isset($group->displayName)) {
-						$newGroup->setDisplayName($group->displayName);
-					}
+				if (isset($group->displayName)) {
+					$newGroup->setDisplayName($group->displayName);
 				}
 			}
 		}
+
+		return $syncGroups;
 	}
+
 
 	public function getGroupWhitelistRegex(int $providerId): string {
 		$regex = $this->providerService->getSetting($providerId, ProviderService::SETTING_GROUP_WHITELIST_REGEX, '');

--- a/tests/unit/Service/ProvisioningServiceTest.php
+++ b/tests/unit/Service/ProvisioningServiceTest.php
@@ -18,6 +18,7 @@ use OCP\IAvatarManager;
 use OCP\IConfig;
 use OCP\IGroup;
 use OCP\IGroupManager;
+use OCP\ISession;
 use OCP\IUser;
 use OCP\IUserManager;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -61,6 +62,9 @@ class ProvisioningServiceTest extends TestCase {
 	/** @var IAvatarManager | MockObject */
 	private $avatarManager;
 
+	/** @var ISession | MockObject */
+	private $session;
+
 	public function setUp(): void {
 		parent::setUp();
 		$this->idService = $this->createMock(LocalIdService::class);
@@ -75,6 +79,7 @@ class ProvisioningServiceTest extends TestCase {
 		$this->clientService = $this->createMock(IClientService::class);
 		$this->avatarManager = $this->createMock(IAvatarManager::class);
 		$this->config = $this->createMock(IConfig::class);
+		$this->session = $this->createMock(ISession::class);
 
 		$this->provisioningService = new ProvisioningService(
 			$this->idService,
@@ -88,6 +93,7 @@ class ProvisioningServiceTest extends TestCase {
 			$this->clientService,
 			$this->avatarManager,
 			$this->config,
+			$this->session,
 		);
 	}
 


### PR DESCRIPTION
This adds global scale support in user_oidc.
This requires https://github.com/nextcloud/globalsiteselector/pull/168

* Adjust `LoginController::singleLogoutService` to get the provider ID from the GSS logout JWT token
* Adjust the provisioning service to get the user information needed by GSS and store it in the session (uid, email, display name, quota and groups)
* Adjust the user backend: add getUserData (inspired by user_saml) to format the user data for the GSS master


Questions/doubts:

* In `LoginController::singleLogoutService` we try to get the OIDC login token from the session to optionally pass it as a GET parameter to the "end session endpoint" of the OIDC provider. If the session has died on the GSS master, this won't work. We will pass an empty login token. How bad is this?
* We don't support the backchannel logout yet