### PR TITLE
fix: Avoid slow queries in scenarios where we do not need a search

### DIFF
--- a/lib/Service/LdapService.php
+++ b/lib/Service/LdapService.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\UserOIDC\Service;
 
+use OCP\App\IAppManager;
 use OCP\AppFramework\QueryException;
 use OCP\IUser;
 use Psr\Log\LoggerInterface;
@@ -16,7 +17,12 @@ class LdapService {
 
 	public function __construct(
 		private LoggerInterface $logger,
+		private IAppManager $appManager,
 	) {
+	}
+
+	public function isLDAPEnabled(): bool {
+		return $this->appManager->isEnabledForUser('user_ldap');
 	}
 
 	/**
@@ -26,6 +32,10 @@ class LdapService {
 	 * @throws \Psr\Container\NotFoundExceptionInterface
 	 */
 	public function isLdapDeletedUser(IUser $user): bool {
+		if ($this->isLDAPEnabled()) {
+			return false;
+		}
+
 		$className = $user->getBackendClassName();
 		if ($className !== 'LDAP') {
 			return false;

--- a/lib/Service/ProvisioningService.php
+++ b/lib/Service/ProvisioningService.php
@@ -10,6 +10,8 @@ namespace OCA\UserOIDC\Service;
 use OCA\UserOIDC\Db\UserMapper;
 use OCA\UserOIDC\Event\AttributeMappedEvent;
 use OCP\Accounts\IAccountManager;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\DB\Exception;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Http\Client\IClientService;
@@ -38,6 +40,15 @@ class ProvisioningService {
 		private IAvatarManager $avatarManager,
 		private IConfig $config,
 	) {
+	}
+
+	public function hasOidcUserProvisitioned(string $userId): bool {
+		try {
+			$this->userMapper->getUser($userId);
+			return true;
+		} catch (DoesNotExistException|MultipleObjectsReturnedException) {
+		}
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Searching users can be slow and we only need it in case of ldap provisioning, so we can skip otherwise. Additionally we can limit the results to make the query possibly faster when it is used.