### PR TITLE
fix(token-refresh): handle missing attributes in login token

### DIFF
--- a/docs/token_exchange.md
+++ b/docs/token_exchange.md
@@ -6,6 +6,13 @@
 
 If your IdP supports token exchange, user_oidc can exchange the login token against another token.
 
+:warning: The token exchange feature is disabled by default. You can enable it in `config.php`:
+``` php
+'user_oidc' => [
+    'token_exchange' => true,
+],
+```
+
 Keycloak supports token exchange if its "Preview" mode is enabled. See https://www.keycloak.org/securing-apps/token-exchange .
 
 :warning: Your IdP need to be configured accordingly. For example, Keycloak requires that token exchange is explicitely

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -518,12 +518,15 @@ class LoginController extends BaseOidcController {
 			$this->eventDispatcher->dispatchTyped(new UserLoggedInEvent($user, $user->getUID(), null, false));
 		}
 
-		// store all token information for potential token exchange requests
-		$tokenData = array_merge(
-			$data,
-			['provider_id' => $providerId],
-		);
-		$this->tokenService->storeToken($tokenData);
+		$tokenExchangeEnabled = (isset($oidcSystemConfig['token_exchange']) && $oidcSystemConfig['token_exchange'] === true);
+		if ($tokenExchangeEnabled) {
+			// store all token information for potential token exchange requests
+			$tokenData = array_merge(
+				$data,
+				['provider_id' => $providerId],
+			);
+			$this->tokenService->storeToken($tokenData);
+		}
 		$this->config->setUserValue($user->getUID(), Application::APP_ID, 'had_token_once', '1');
 
 		// Set last password confirm to the future as we don't have passwords to confirm against with SSO

--- a/lib/Model/Token.php
+++ b/lib/Model/Token.php
@@ -16,7 +16,7 @@ class Token implements JsonSerializable {
 	private string $accessToken;
 	private int $expiresIn;
 	private ?int $refreshExpiresIn;
-	private string $refreshToken;
+	private ?string $refreshToken;
 	private int $createdAt;
 	private ?int $providerId;
 
@@ -25,7 +25,7 @@ class Token implements JsonSerializable {
 		$this->accessToken = $tokenData['access_token'];
 		$this->expiresIn = $tokenData['expires_in'];
 		$this->refreshExpiresIn = $tokenData['refresh_expires_in'] ?? null;
-		$this->refreshToken = $tokenData['refresh_token'];
+		$this->refreshToken = $tokenData['refresh_token'] ?? null;
 		$this->createdAt = $tokenData['created_at'] ?? time();
 		$this->providerId = $tokenData['provider_id'] ?? null;
 	}
@@ -61,7 +61,7 @@ class Token implements JsonSerializable {
 		return $refreshExpiresAt - time();
 	}
 
-	public function getRefreshToken(): string {
+	public function getRefreshToken(): ?string {
 		return $this->refreshToken;
 	}
 

--- a/lib/Model/Token.php
+++ b/lib/Model/Token.php
@@ -15,7 +15,7 @@ class Token implements JsonSerializable {
 	private ?string $idToken;
 	private string $accessToken;
 	private int $expiresIn;
-	private int $refreshExpiresIn;
+	private ?int $refreshExpiresIn;
 	private string $refreshToken;
 	private int $createdAt;
 	private ?int $providerId;
@@ -24,7 +24,7 @@ class Token implements JsonSerializable {
 		$this->idToken = $tokenData['id_token'] ?? null;
 		$this->accessToken = $tokenData['access_token'];
 		$this->expiresIn = $tokenData['expires_in'];
-		$this->refreshExpiresIn = $tokenData['refresh_expires_in'];
+		$this->refreshExpiresIn = $tokenData['refresh_expires_in'] ?? null;
 		$this->refreshToken = $tokenData['refresh_token'];
 		$this->createdAt = $tokenData['created_at'] ?? time();
 		$this->providerId = $tokenData['provider_id'] ?? null;
@@ -47,11 +47,16 @@ class Token implements JsonSerializable {
 		return $expiresAt - time();
 	}
 
-	public function getRefreshExpiresIn(): int {
+	public function getRefreshExpiresIn(): ?int {
 		return $this->refreshExpiresIn;
 	}
 
 	public function getRefreshExpiresInFromNow(): int {
+		// if there is no refresh_expires_in, we assume the refresh token never expires
+		// so we don't need getRefreshExpiresInFromNow
+		if ($this->refreshExpiresIn === null) {
+			return 0;
+		}
 		$refreshExpiresAt = $this->createdAt + $this->refreshExpiresIn;
 		return $refreshExpiresAt - time();
 	}
@@ -73,10 +78,18 @@ class Token implements JsonSerializable {
 	}
 
 	public function refreshIsExpired(): bool {
+		// if there is no refresh_expires_in, we assume the refresh token never expires
+		if ($this->refreshExpiresIn === null) {
+			return false;
+		}
 		return time() > ($this->createdAt + $this->refreshExpiresIn);
 	}
 
 	public function refreshIsExpiring(): bool {
+		// if there is no refresh_expires_in, we assume the refresh token never expires
+		if ($this->refreshExpiresIn === null) {
+			return false;
+		}
 		return time() > ($this->createdAt + (int)($this->refreshExpiresIn / 2));
 	}
 

--- a/lib/Service/TokenService.php
+++ b/lib/Service/TokenService.php
@@ -102,6 +102,12 @@ class TokenService {
 	 * @throws PreConditionNotMetException
 	 */
 	public function checkLoginToken(): void {
+		$oidcSystemConfig = $this->config->getSystemValue('user_oidc', []);
+		$tokenExchangeEnabled = (isset($oidcSystemConfig['token_exchange']) && $oidcSystemConfig['token_exchange'] === true);
+		if (!$tokenExchangeEnabled) {
+			return;
+		}
+
 		$currentUser = $this->userSession->getUser();
 		if (!$this->userSession->isLoggedIn() || $currentUser === null) {
 			$this->logger->debug('[TokenService] checkLoginToken: user not logged in');
@@ -212,6 +218,15 @@ class TokenService {
 	 * @throws \JsonException
 	 */
 	public function getExchangedToken(string $targetAudience): Token {
+		$oidcSystemConfig = $this->config->getSystemValue('user_oidc', []);
+		$tokenExchangeEnabled = (isset($oidcSystemConfig['token_exchange']) && $oidcSystemConfig['token_exchange'] === true);
+		if (!$tokenExchangeEnabled) {
+			throw new TokenExchangeFailedException(
+				'Failed to exchange token, the token exchange feature is disabled. It can be enabled in config.php',
+				0,
+			);
+		}
+
 		$loginToken = $this->getToken();
 		if ($loginToken === null) {
 			$this->logger->debug('[TokenService] Failed to exchange token, no login token found in the session');

--- a/lib/Service/TokenService.php
+++ b/lib/Service/TokenService.php
@@ -84,8 +84,8 @@ class TokenService {
 		}
 
 		// token has expired
-		// try to refresh the token if the refresh token is still valid
-		if ($refreshIfExpired && !$token->refreshIsExpired()) {
+		// try to refresh the token if there is a refresh token and it is still valid
+		if ($refreshIfExpired && $token->getRefreshToken() !== null && !$token->refreshIsExpired()) {
 			$this->logger->debug('[TokenService] getToken: token is expired and refresh token is still valid, refresh expires in ' . $token->getRefreshExpiresInFromNow());
 			return $this->refresh($token);
 		}


### PR DESCRIPTION
closes #1024

This fixes a crash if `refresh_expires_in` or `refresh_token` are missing from the login token.

If `refresh_expires_in` is missing, let's consider the refresh token never expires.
If the refresh token is missing, let's not try to refresh the login token.

Let's also make the whole token exchange feature disabled by default.