### PR TITLE
Remove AZP check when validating a bearer ID token

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,14 +291,14 @@ sudo -u www-data php /var/www/nextcloud/occ user_oidc:provider demoprovider \
 
 ### Disable audience and azp checks
 
-The `audience` and `azp` token claims will be checked when validating a login or bearer ID token.
-You can disable these check with these config value (in config.php):
+The `audience` and `azp` token claims will be checked when validating a login ID token.
+Only the `audience` will be checked when validating a Bearer token.
+You can disable these checks with these config values (in config.php):
 ``` php
 'user_oidc' => [
     'login_validation_audience_check' => false,
     'login_validation_azp_check' => false,
     'selfencoded_bearer_validation_audience_check' => false,
-    'selfencoded_bearer_validation_azp_check' => false,
 ],
 ```
 

--- a/lib/User/Validator/SelfEncodedValidator.php
+++ b/lib/User/Validator/SelfEncodedValidator.php
@@ -57,6 +57,7 @@ class SelfEncodedValidator implements IBearerTokenValidator {
 		}
 
 		$oidcSystemConfig = $this->config->getSystemValue('user_oidc', []);
+		// ref https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
 		$checkAudience = !isset($oidcSystemConfig['selfencoded_bearer_validation_audience_check'])
 			|| !in_array($oidcSystemConfig['selfencoded_bearer_validation_audience_check'], [false, 'false', 0, '0'], true);
 		$providerClientId = $provider->getClientId();
@@ -67,17 +68,6 @@ class SelfEncodedValidator implements IBearerTokenValidator {
 					|| (is_array($tokenAudience) && !in_array($providerClientId, $tokenAudience, true))
 			) {
 				$this->logger->debug('This token is not for us, the audience does not match the client ID');
-				return null;
-			}
-		}
-
-		$checkAzp = !isset($oidcSystemConfig['selfencoded_bearer_validation_azp_check'])
-			|| !in_array($oidcSystemConfig['selfencoded_bearer_validation_azp_check'], [false, 'false', 0, '0'], true);
-		if ($checkAzp) {
-			// ref https://openid.net/specs/openid-connect-core-1_0.html#IDTokenValidation
-			// If the azp claim is present, it should be the client ID
-			if (isset($payload->azp) && $payload->azp !== $providerClientId) {
-				$this->logger->debug('This token is not for us, authorized party (azp) is different than the client ID');
 				return null;
 			}
 		}


### PR DESCRIPTION
closes #1038

As explained in #1038, checking the AZP (authorized party) only makes sense when validating an ID token that is for ourselves (during login, in our context). So let's remove it from `SelfEncodedValidator::isValidBearerToken`.