### PR TITLE
docs: Replace broken jumpstart docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 OpenID Connect user backend for Nextcloud
 
 ## General usage
-See [Nextcloud and OpenID-Connect](https://www.schiessle.org/articles/2023/07/04/nextcloud-and-openid-connect/)
+See [Nextcloud and OpenID-Connect](https://web.archive.org/web/20240412121655/https://www.schiessle.org/articles/2023/07/04/nextcloud-and-openid-connect/)
 for a proper jumpstart.
 
 ### User IDs


### PR DESCRIPTION
@schiessle's web site appears to have gone offline recently. Changed the link to use archive.org/Wayback Machine to be more "permanent".