### PR TITLE
Fix password confirmation

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 	<name>OpenID Connect user backend</name>
 	<summary>Use an OpenID Connect backend to login to your Nextcloud</summary>
 	<description>Allows flexible configuration of an OIDC server as Nextcloud login user backend.</description>
-	<version>6.3.0</version>
+	<version>7.0.0</version>
 	<licence>agpl</licence>
 	<author>Roeland Jago Douma</author>
 	<author>Julius Härtl</author>
@@ -23,7 +23,7 @@
 	<bugs>https://github.com/nextcloud/user_oidc/issues</bugs>
 	<repository>https://github.com/nextcloud/user_oidc</repository>
 	<dependencies>
-		<nextcloud min-version="26" max-version="32"/>
+		<nextcloud min-version="28" max-version="32"/>
 	</dependencies>
 	<settings>
 		<admin>OCA\UserOIDC\Settings\AdminSettings</admin>

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -36,6 +36,7 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\Authentication\Token\IToken;
 use OCP\DB\Exception;
 use OCP\EventDispatcher\IEventDispatcher;
 use OCP\Http\Client\IClientService;
@@ -520,6 +521,14 @@ class LoginController extends BaseOidcController {
 			$this->userSession->completeLogin($user, ['loginName' => $user->getUID(), 'password' => '']);
 			$this->userSession->createSessionToken($this->request, $user->getUID(), $user->getUID());
 			$this->userSession->createRememberMeToken($user);
+
+			// prevent password confirmation
+			if (defined(IToken::class . '::SCOPE_SKIP_PASSWORD_VALIDATION')) {
+				$token = $this->authTokenProvider->getToken($this->session->getId());
+				$token->setScope([IToken::SCOPE_SKIP_PASSWORD_VALIDATION => true]);
+				$this->authTokenProvider->updateToken($token);
+			}
+
 			// TODO server should/could be refactored so we don't need to manually create the user session and dispatch the login-related events
 			// Warning! If GSS is used, it reacts to the BeforeUserLoggedInEvent and handles the redirection itself
 			// So nothing after dispatching this event will be executed

--- a/lib/User/Backend.php
+++ b/lib/User/Backend.php
@@ -280,9 +280,11 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 								}
 							}
 
+							$this->session->set('last-password-confirm', strtotime('+4 year', time()));
 							return $userId;
 						} elseif ($this->userExists($tokenUserId)) {
 							$this->checkFirstLogin($tokenUserId);
+							$this->session->set('last-password-confirm', strtotime('+4 year', time()));
 							return $tokenUserId;
 						} else {
 							// check if the user exists locally
@@ -303,6 +305,7 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 								return '';
 							}
 							$this->checkFirstLogin($tokenUserId);
+							$this->session->set('last-password-confirm', strtotime('+4 year', time()));
 							return $tokenUserId;
 						}
 					}


### PR DESCRIPTION
refs https://github.com/nextcloud/server/issues/43612

1. Replicate what's done in user_saml's user backend with the session: Set `last-password-confirm` in the session everytime the user ID is obtained in `OCA\UserOIDC\User\Backend::getCurrentUserId()`
2. Adjust auth token scope in login controller. Inspired by https://github.com/nextcloud/server/pull/43942/files#diff-b30a8c4cef5da5cede4d9038c16ede43e1746f85270e4249598fd305b0fa77deR173-R176
3. Bump min NC version to 28 to make sure we have `OCP\Authentication\Token\IToken`
4. Only do 2. if `IToken::SCOPE_SKIP_PASSWORD_VALIDATION` is defined (it was introduced in 30)


Maybe 1. is not necessary. Wdyt?