### PR TITLE
broadcast prelogin event before login event

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -517,13 +517,15 @@ class LoginController extends BaseOidcController {
 
 		$this->userSession->setUser($user);
 		if ($this->userSession instanceof OC_UserSession) {
-			$this->userSession->completeLogin($user, ['loginName' => $user->getUID(), 'password' => '']);
-			$this->userSession->createSessionToken($this->request, $user->getUID(), $user->getUID());
-			$this->userSession->createRememberMeToken($user);
 			// TODO server should/could be refactored so we don't need to manually create the user session and dispatch the login-related events
 			// Warning! If GSS is used, it reacts to the BeforeUserLoggedInEvent and handles the redirection itself
 			// So nothing after dispatching this event will be executed
-			$this->eventDispatcher->dispatchTyped(new BeforeUserLoggedInEvent($user->getUID(), null, \OC::$server->get(Backend::class)));
+			$this->eventDispatcher->dispatchTyped(new BeforeUserLoggedInEvent($user->getUID(), null, \OCP\Server::get(Backend::class)));
+
+			$this->userSession->completeLogin($user, ['loginName' => $user->getUID(), 'password' => '']);
+			$this->userSession->createSessionToken($this->request, $user->getUID(), $user->getUID());
+			$this->userSession->createRememberMeToken($user);
+
 			$this->eventDispatcher->dispatchTyped(new UserLoggedInEvent($user, $user->getUID(), null, false));
 		}
 


### PR DESCRIPTION
The fix the fact that, on global scale, a session is authed on master.