### PR TITLE
prepare 6.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 6.3.1 – 2025-02-25
+
+### Fixed
+
+- Add missing group-provisioning options in upsert command @bjalbor [#1063](https://github.com/nextcloud/user_oidc/pull/1063)
+- Dispatch prelogin event before login event @ArtificialOwl [#1065](https://github.com/nextcloud/user_oidc/pull/1065)
+
 ## 6.3.0 – 2025-02-17
 
 ### Changed

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 	<name>OpenID Connect user backend</name>
 	<summary>Use an OpenID Connect backend to login to your Nextcloud</summary>
 	<description>Allows flexible configuration of an OIDC server as Nextcloud login user backend.</description>
-	<version>6.3.0</version>
+	<version>6.3.1</version>
 	<licence>agpl</licence>
 	<author>Roeland Jago Douma</author>
 	<author>Julius Härtl</author>


### PR DESCRIPTION
### Fixed

- Add missing group-provisioning options in upsert command @bjalbor [#1063](https://github.com/nextcloud/user_oidc/pull/1063)
- Dispatch prelogin event before login event @ArtificialOwl [#1065](https://github.com/nextcloud/user_oidc/pull/1065)