### PR TITLE
Clarify events/listeners to get a token

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,14 +294,6 @@ If you want to ask the [OIDC Identity Provider app](https://apps.nextcloud.com/a
 ```
 This requires the OIDC Identity Provider app >= v1.4.0 . Access tokens and JWT tokens can be validated.
 
-If you want to ask the [OIDC Identity Provider app](https://apps.nextcloud.com/apps/oidc) to generate a token when user_oidc receives a token exchange request event:
-``` php
-'user_oidc' => [
-    'oidc_provider_token_generation' => true,
-],
-```
-This requires the OIDC Identity Provider app >= v1.4.0 . An access token and a JWT token are generated.
-
 ### Group provisioning
 
 You can configure each provider:

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -6,6 +6,12 @@ SPDX-PackageSupplier = "Nextcloud <info@nextcloud.com>"
 SPDX-PackageDownloadLocation = "https://github.com/nextcloud/user_oidc"
 
 [[annotations]]
+path = ["l10n/**.js", "l10n/**.json"]
+precedence = "aggregate"
+SPDX-FileCopyrightText = "2023-2023 Nextcloud translators"
+SPDX-License-Identifier = "AGPL-3.0-or-later"
+
+[[annotations]]
 path = [".tx/config", "composer.json", "composer.lock", "package.json", "package-lock.json"]
 precedence = "aggregate"
 SPDX-FileCopyrightText = "2020 Nextcloud GmbH and Nextcloud contributors"

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -28,6 +28,7 @@ return [
 		['name' => 'Settings#updateProvider', 'url' => '/provider/{providerId}', 'verb' => 'PUT'],
 		['name' => 'Settings#deleteProvider', 'url' => '/provider/{providerId}', 'verb' => 'DELETE'],
 		['name' => 'Settings#setID4ME', 'url' => '/provider/id4me', 'verb' => 'POST'],
+		['name' => 'Settings#setAdminConfig', 'url' => '/admin-config', 'verb' => 'POST'],
 
 		['name' => 'Timezone#setTimezone', 'url' => '/config/timezone', 'verb' => 'POST'],
 	],

--- a/docs/token_events.md
+++ b/docs/token_events.md
@@ -1,0 +1,76 @@
+<!--
+  - SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+  - SPDX-License-Identifier: AGPL-3.0-or-later
+-->
+# Token events
+
+Other apps can ask user_oidc for the login token (the one obtained when logging in Nextcloud using an external Oidc provider)
+or a token from the "oidc" app (https://apps.nextcloud.com/apps/oidc). Those tokens might be useful for integration apps
+that need to authenticate against another service's API.
+
+## Get a token from an external provider
+
+This is possible to get the current user's login token by emitting an event which will be received by user_oidc.
+This is also possible to ask user_oidc to perform a token exchange, see token_exchange.md.
+In this paragraph, we only talk about getting the login token (or a refreshed one), meaning it is delivered for the Oidc
+client that was used when the user logged in Nextcloud.
+
+To get the token obtained on login, user_oidc needs to store it and refresh it when needed. This is disabled by default.
+You can enable this in `config.php`:
+``` php
+'user_oidc' => [
+    'store_login_token' => true,
+],
+```
+This login token is refreshed by user_oidc when needed. So the token you will get by emitting the event will be valid (not expired).
+
+Any Nextcloud app can emit the `ExternalTokenRequestedEvent` event:
+```php
+if (class_exists(OCA\UserOIDC\Event\ExternalTokenRequestedEvent::class)) {
+	$event = new OCA\UserOIDC\Event\ExternalTokenRequestedEvent();
+	try {
+		$this->eventDispatcher->dispatchTyped($event);
+	} catch (OCA\UserOIDC\Exception\GetExternalTokenFailedException $e) {
+		$this->logger->debug('Failed to get external token: ' . $e->getMessage());
+		$error = $e->getError();
+		$errorDescription = $e->getErrorDescription();
+		if ($error && $errorDescription) {
+			$this->logger->debug('Token exchange error response from the IdP: ' . $error . ' (' . $errorDescription . ')');
+		}
+	}
+	$token = $event->getToken();
+	if ($token === null) {
+		$this->logger->debug('There was no token found in the session');
+	} else {
+		$this->logger->debug('Obtained a token that expires in ' . $token->getExpiresInFromNow());
+		// use the token
+		$accessToken = $token->getAccessToken();
+		$idToken = $token->getIdToken();
+	}
+} else {
+	$this->logger->debug('The user_oidc app is not installed/available');
+}
+```
+
+## Get an internal token
+
+To get a token from the internal Oidc provider ("oidc" app), the `InternalTokenRequestedEvent` can be emitted.
+No need to enable `store_login_token`.
+
+```php
+if (class_exists(OCA\UserOIDC\Event\InternalTokenRequestedEvent::class)) {
+	$event = new OCA\UserOIDC\Event\InternalTokenRequestedEvent('my_target_audience');
+    $this->eventDispatcher->dispatchTyped($event);
+	$token = $event->getToken();
+	if ($token === null) {
+		$this->logger->debug('InternalTokenRequestedEvent, no token has been obtained from the oidc app');
+	} else {
+		$this->logger->debug('Obtained a token that expires in ' . $token->getExpiresInFromNow());
+		// use the token
+		$accessToken = $token->getAccessToken();
+		$idToken = $token->getIdToken();
+	}
+} else {
+	$this->logger->debug('The user_oidc app is not installed/available');
+}
+```

--- a/docs/token_events.md
+++ b/docs/token_events.md
@@ -16,11 +16,9 @@ In this paragraph, we only talk about getting the login token (or a refreshed on
 client that was used when the user logged in Nextcloud.
 
 To get the token obtained on login, user_oidc needs to store it and refresh it when needed. This is disabled by default.
-You can enable this in `config.php`:
-``` php
-'user_oidc' => [
-    'store_login_token' => true,
-],
+You can enable this with:
+``` bash
+sudo -u www-data php /var/www/nextcloud/occ config:app:set --value=1 user_oidc store_login_token
 ```
 This login token is refreshed by user_oidc when needed. So the token you will get by emitting the event will be valid (not expired).
 

--- a/docs/token_exchange.md
+++ b/docs/token_exchange.md
@@ -6,10 +6,10 @@
 
 If your IdP supports token exchange, user_oidc can exchange the login token against another token.
 
-:warning: The token exchange feature is disabled by default. You can enable it in `config.php`:
+:warning: The token exchange feature requires to store the login token which is disabled by default. You can enable it in `config.php`:
 ``` php
 'user_oidc' => [
-    'token_exchange' => true,
+    'store_login_token' => true,
 ],
 ```
 
@@ -32,7 +32,7 @@ it can dispatch the `OCA\UserOIDC\Event\ExchangedTokenRequestedEvent` event.
 The exchanged token is immediately stored in the event object itself.
 
 ```php
-if (class_exists('OCA\UserOIDC\Event\ExchangedTokenRequestedEvent')) {
+if (class_exists(OCA\UserOIDC\Event\ExchangedTokenRequestedEvent:class)) {
 	$event = new OCA\UserOIDC\Event\ExchangedTokenRequestedEvent('my_target_audience');
 	try {
 		$this->eventDispatcher->dispatchTyped($event);
@@ -51,6 +51,7 @@ if (class_exists('OCA\UserOIDC\Event\ExchangedTokenRequestedEvent')) {
 		$this->logger->debug('Obtained a token that expires in ' . $token->getExpiresInFromNow());
 		// use the token
 		$accessToken = $token->getAccessToken();
+		$idToken = $token->getIdToken();
 	}
 } else {
 	$this->logger->debug('The user_oidc app is not installed/available');

--- a/docs/token_exchange.md
+++ b/docs/token_exchange.md
@@ -6,11 +6,9 @@
 
 If your IdP supports token exchange, user_oidc can exchange the login token against another token.
 
-:warning: The token exchange feature requires to store the login token which is disabled by default. You can enable it in `config.php`:
-``` php
-'user_oidc' => [
-    'store_login_token' => true,
-],
+:warning: The token exchange feature requires to store the login token which is disabled by default. You can enable it with:
+``` bash
+sudo -u www-data php /var/www/nextcloud/occ config:app:set --value=1 user_oidc store_login_token
 ```
 
 Keycloak supports token exchange if its "Preview" mode is enabled. See https://www.keycloak.org/securing-apps/token-exchange .

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -14,7 +14,11 @@ use OC_User;
 use OCA\Files\Event\LoadAdditionalScriptsEvent;
 use OCA\UserOIDC\Db\ProviderMapper;
 use OCA\UserOIDC\Event\ExchangedTokenRequestedEvent;
+use OCA\UserOIDC\Event\ExternalTokenRequestedEvent;
+use OCA\UserOIDC\Event\InternalTokenRequestedEvent;
 use OCA\UserOIDC\Listener\ExchangedTokenRequestedListener;
+use OCA\UserOIDC\Listener\ExternalTokenRequestedListener;
+use OCA\UserOIDC\Listener\InternalTokenRequestedListener;
 use OCA\UserOIDC\Listener\TimezoneHandlingListener;
 use OCA\UserOIDC\Service\ID4MeService;
 use OCA\UserOIDC\Service\SettingsService;
@@ -57,6 +61,8 @@ class Application extends App implements IBootstrap {
 
 		$context->registerEventListener(LoadAdditionalScriptsEvent::class, TimezoneHandlingListener::class);
 		$context->registerEventListener(ExchangedTokenRequestedEvent::class, ExchangedTokenRequestedListener::class);
+		$context->registerEventListener(ExternalTokenRequestedEvent::class, ExternalTokenRequestedListener::class);
+		$context->registerEventListener(InternalTokenRequestedEvent::class, InternalTokenRequestedListener::class);
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -539,8 +539,8 @@ class LoginController extends BaseOidcController {
 			$this->eventDispatcher->dispatchTyped(new UserLoggedInEvent($user, $user->getUID(), null, false));
 		}
 
-		$tokenExchangeEnabled = (isset($oidcSystemConfig['token_exchange']) && $oidcSystemConfig['token_exchange'] === true);
-		if ($tokenExchangeEnabled) {
+		$storeLoginTokenEnabled = (isset($oidcSystemConfig['store_login_token']) && $oidcSystemConfig['store_login_token'] === true);
+		if ($storeLoginTokenEnabled) {
 			// store all token information for potential token exchange requests
 			$tokenData = array_merge(
 				$data,

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -539,7 +539,7 @@ class LoginController extends BaseOidcController {
 			$this->eventDispatcher->dispatchTyped(new UserLoggedInEvent($user, $user->getUID(), null, false));
 		}
 
-		$storeLoginTokenEnabled = (isset($oidcSystemConfig['store_login_token']) && $oidcSystemConfig['store_login_token'] === true);
+		$storeLoginTokenEnabled = $this->config->getAppValue(Application::APP_ID, 'store_login_token', '0') === '1';
 		if ($storeLoginTokenEnabled) {
 			// store all token information for potential token exchange requests
 			$tokenData = array_merge(

--- a/lib/Event/ExternalTokenRequestedEvent.php
+++ b/lib/Event/ExternalTokenRequestedEvent.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\UserOIDC\Event;
+
+use OCA\UserOIDC\Model\Token;
+use OCP\EventDispatcher\Event;
+
+/**
+ * This event is emitted by other apps which need the token that was obtained when logging in Nextcloud
+ */
+class ExternalTokenRequestedEvent extends Event {
+
+	private ?Token $token = null;
+
+	public function __construct() {
+		parent::__construct();
+	}
+
+	public function getToken(): ?Token {
+		return $this->token;
+	}
+
+	public function setToken(?Token $token): void {
+		$this->token = $token;
+	}
+}

--- a/lib/Event/InternalTokenRequestedEvent.php
+++ b/lib/Event/InternalTokenRequestedEvent.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\UserOIDC\Event;
+
+use OCA\UserOIDC\Model\Token;
+use OCP\EventDispatcher\Event;
+
+/**
+ * This event is emitted by other apps which need a token from the internal Oidc provider (the "oidc" app)
+ */
+class InternalTokenRequestedEvent extends Event {
+
+	private ?Token $token = null;
+
+	public function __construct(
+		private string $targetAudience,
+	) {
+		parent::__construct();
+	}
+
+	public function getTargetAudience(): string {
+		return $this->targetAudience;
+	}
+
+	public function setTargetAudience(string $targetAudience): void {
+		$this->targetAudience = $targetAudience;
+	}
+
+	public function getToken(): ?Token {
+		return $this->token;
+	}
+
+	public function setToken(?Token $token): void {
+		$this->token = $token;
+	}
+}

--- a/lib/Exception/GetExternalTokenFailedException.php
+++ b/lib/Exception/GetExternalTokenFailedException.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\UserOIDC\Exception;
+
+use Exception;
+
+class GetExternalTokenFailedException extends Exception {
+
+	public function __construct(
+		$message = '',
+		$code = 0,
+		$previous = null,
+		private ?string $error = null,
+		private ?string $errorDescription = null,
+	) {
+		parent::__construct($message, $code, $previous);
+	}
+
+	public function getError(): ?string {
+		return $this->error;
+	}
+
+	public function getErrorDescription(): ?string {
+		return $this->errorDescription;
+	}
+}

--- a/lib/Listener/ExchangedTokenRequestedListener.php
+++ b/lib/Listener/ExchangedTokenRequestedListener.php
@@ -12,7 +12,6 @@ use OCA\UserOIDC\Event\ExchangedTokenRequestedEvent;
 use OCA\UserOIDC\Service\TokenService;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
-use OCP\IConfig;
 use OCP\IUserSession;
 use Psr\Log\LoggerInterface;
 
@@ -25,7 +24,6 @@ class ExchangedTokenRequestedListener implements IEventListener {
 		private IUserSession $userSession,
 		private TokenService $tokenService,
 		private LoggerInterface $logger,
-		private IConfig $config,
 	) {
 	}
 
@@ -39,21 +37,7 @@ class ExchangedTokenRequestedListener implements IEventListener {
 		}
 
 		$targetAudience = $event->getTargetAudience();
-		$this->logger->debug('[TokenExchange Listener] received request for audience: ' . $targetAudience);
-
-		// generate a token pair with the Oidc provider app
-		$oidcSystemConfig = $this->config->getSystemValue('user_oidc', []);
-		$ncProviderTokenGenerationEnabled = (isset($oidcSystemConfig['oidc_provider_token_generation']) && $oidcSystemConfig['oidc_provider_token_generation'] === true);
-		if ($ncProviderTokenGenerationEnabled) {
-			$userId = $this->userSession->getUser()?->getUID();
-			if ($userId !== null) {
-				$ncProviderToken = $this->tokenService->getTokenFromOidcProviderApp($userId, $targetAudience);
-				if ($ncProviderToken !== null) {
-					$event->setToken($ncProviderToken);
-					return;
-				}
-			}
-		}
+		$this->logger->debug('[ExchangedTokenRequestedListener] received request for audience: ' . $targetAudience);
 
 		// classic token exchange with an external provider
 		$token = $this->tokenService->getExchangedToken($targetAudience);

--- a/lib/Listener/ExternalTokenRequestedListener.php
+++ b/lib/Listener/ExternalTokenRequestedListener.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace OCA\UserOIDC\Listener;
 
+use OCA\UserOIDC\AppInfo\Application;
 use OCA\UserOIDC\Event\ExternalTokenRequestedEvent;
 use OCA\UserOIDC\Exception\GetExternalTokenFailedException;
 use OCA\UserOIDC\Service\TokenService;
@@ -41,8 +42,7 @@ class ExternalTokenRequestedListener implements IEventListener {
 
 		$this->logger->debug('[ExternalTokenRequestedListener] received request');
 
-		$oidcSystemConfig = $this->config->getSystemValue('user_oidc', []);
-		$storeLoginTokenEnabled = (isset($oidcSystemConfig['store_login_token']) && $oidcSystemConfig['store_login_token'] === true);
+		$storeLoginTokenEnabled = $this->config->getAppValue(Application::APP_ID, 'store_login_token', '0') === '1';
 		if (!$storeLoginTokenEnabled) {
 			throw new GetExternalTokenFailedException('Failed to get external token, login token is not stored', 0);
 		}

--- a/lib/Listener/ExternalTokenRequestedListener.php
+++ b/lib/Listener/ExternalTokenRequestedListener.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\UserOIDC\Listener;
+
+use OCA\UserOIDC\Event\ExternalTokenRequestedEvent;
+use OCA\UserOIDC\Exception\GetExternalTokenFailedException;
+use OCA\UserOIDC\Service\TokenService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IConfig;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @implements IEventListener<ExternalTokenRequestedEvent|Event>
+ */
+class ExternalTokenRequestedListener implements IEventListener {
+
+	public function __construct(
+		private IUserSession $userSession,
+		private TokenService $tokenService,
+		private IConfig $config,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof ExternalTokenRequestedEvent) {
+			return;
+		}
+
+		if (!$this->userSession->isLoggedIn()) {
+			return;
+		}
+
+		$this->logger->debug('[ExternalTokenRequestedListener] received request');
+
+		$oidcSystemConfig = $this->config->getSystemValue('user_oidc', []);
+		$storeLoginTokenEnabled = (isset($oidcSystemConfig['store_login_token']) && $oidcSystemConfig['store_login_token'] === true);
+		if (!$storeLoginTokenEnabled) {
+			throw new GetExternalTokenFailedException('Failed to get external token, login token is not stored', 0);
+		}
+
+		$token = $this->tokenService->getToken();
+		$event->setToken($token);
+	}
+}

--- a/lib/Listener/InternalTokenRequestedListener.php
+++ b/lib/Listener/InternalTokenRequestedListener.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\UserOIDC\Listener;
+
+use OCA\UserOIDC\Event\InternalTokenRequestedEvent;
+use OCA\UserOIDC\Service\TokenService;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IUserSession;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @implements IEventListener<InternalTokenRequestedEvent|Event>
+ */
+class InternalTokenRequestedListener implements IEventListener {
+
+	public function __construct(
+		private IUserSession $userSession,
+		private TokenService $tokenService,
+		private LoggerInterface $logger,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof InternalTokenRequestedEvent) {
+			return;
+		}
+
+		if (!$this->userSession->isLoggedIn()) {
+			return;
+		}
+
+		$targetAudience = $event->getTargetAudience();
+		$this->logger->debug('[InternalTokenRequestedListener] received request for audience: ' . $targetAudience);
+
+		// generate a token pair with the Oidc provider app
+		$userId = $this->userSession->getUser()?->getUID();
+		if ($userId !== null) {
+			$ncProviderToken = $this->tokenService->getTokenFromOidcProviderApp($userId, $targetAudience);
+			if ($ncProviderToken !== null) {
+				$event->setToken($ncProviderToken);
+			}
+		}
+	}
+}

--- a/lib/Service/TokenService.php
+++ b/lib/Service/TokenService.php
@@ -106,8 +106,7 @@ class TokenService {
 	 * @throws PreConditionNotMetException
 	 */
 	public function checkLoginToken(): void {
-		$oidcSystemConfig = $this->config->getSystemValue('user_oidc', []);
-		$storeLoginTokenEnabled = (isset($oidcSystemConfig['store_login_token']) && $oidcSystemConfig['store_login_token'] === true);
+		$storeLoginTokenEnabled = $this->config->getAppValue(Application::APP_ID, 'store_login_token', '0') === '1';
 		if (!$storeLoginTokenEnabled) {
 			return;
 		}
@@ -222,8 +221,7 @@ class TokenService {
 	 * @throws \JsonException
 	 */
 	public function getExchangedToken(string $targetAudience): Token {
-		$oidcSystemConfig = $this->config->getSystemValue('user_oidc', []);
-		$storeLoginTokenEnabled = (isset($oidcSystemConfig['store_login_token']) && $oidcSystemConfig['store_login_token'] === true);
+		$storeLoginTokenEnabled = $this->config->getAppValue(Application::APP_ID, 'store_login_token', '0') === '1';
 		if (!$storeLoginTokenEnabled) {
 			throw new TokenExchangeFailedException(
 				'Failed to exchange token, storing the login token is disabled. It can be enabled in config.php',

--- a/lib/Service/TokenService.php
+++ b/lib/Service/TokenService.php
@@ -107,8 +107,8 @@ class TokenService {
 	 */
 	public function checkLoginToken(): void {
 		$oidcSystemConfig = $this->config->getSystemValue('user_oidc', []);
-		$tokenExchangeEnabled = (isset($oidcSystemConfig['token_exchange']) && $oidcSystemConfig['token_exchange'] === true);
-		if (!$tokenExchangeEnabled) {
+		$storeLoginTokenEnabled = (isset($oidcSystemConfig['store_login_token']) && $oidcSystemConfig['store_login_token'] === true);
+		if (!$storeLoginTokenEnabled) {
 			return;
 		}
 
@@ -223,10 +223,10 @@ class TokenService {
 	 */
 	public function getExchangedToken(string $targetAudience): Token {
 		$oidcSystemConfig = $this->config->getSystemValue('user_oidc', []);
-		$tokenExchangeEnabled = (isset($oidcSystemConfig['token_exchange']) && $oidcSystemConfig['token_exchange'] === true);
-		if (!$tokenExchangeEnabled) {
+		$storeLoginTokenEnabled = (isset($oidcSystemConfig['store_login_token']) && $oidcSystemConfig['store_login_token'] === true);
+		if (!$storeLoginTokenEnabled) {
 			throw new TokenExchangeFailedException(
-				'Failed to exchange token, the token exchange feature is disabled. It can be enabled in config.php',
+				'Failed to exchange token, storing the login token is disabled. It can be enabled in config.php',
 				0,
 			);
 		}

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -14,6 +14,7 @@ use OCA\UserOIDC\Service\ID4MeService;
 use OCA\UserOIDC\Service\ProviderService;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Services\IInitialState;
+use OCP\IConfig;
 use OCP\IURLGenerator;
 use OCP\Settings\ISettings;
 use OCP\Util;
@@ -24,6 +25,7 @@ class AdminSettings implements ISettings {
 		private ProviderService $providerService,
 		private ID4MeService $Id4MeService,
 		private IURLGenerator $urlGenerator,
+		private IConfig $config,
 		private IInitialState $initialStateService,
 	) {
 	}
@@ -32,6 +34,10 @@ class AdminSettings implements ISettings {
 		$this->initialStateService->provideInitialState(
 			'id4meState',
 			$this->Id4MeService->getID4ME()
+		);
+		$this->initialStateService->provideInitialState(
+			'storeLoginTokenState',
+			$this->config->getAppValue(Application::APP_ID, 'store_login_token', '0') === '1'
 		);
 		$this->initialStateService->provideInitialState(
 			'providers',

--- a/src/main-settings.js
+++ b/src/main-settings.js
@@ -18,6 +18,7 @@ const View = Vue.extend(App)
 new View({
 	propsData: {
 		initialId4MeState: loadState('user_oidc', 'id4meState'),
+		initialStoreLoginTokenState: loadState('user_oidc', 'storeLoginTokenState'),
 		initialProviders: loadState('user_oidc', 'providers'),
 		redirectUrl: loadState('user_oidc', 'redirectUrl'),
 	},


### PR DESCRIPTION
* Cover 3 cases:
    * token exchange
    * get the login token
    * get an internal token (from the 'oidc' app)
* Remove the `token_exchange` and `oidc_provider_token_generation` config settings
* Add a `store_login_token` to enable storing and refreshing the login token (that is necessary for token exchange and getting the login token)
* Add docs

refs https://github.com/nextcloud/integration_openproject/pull/797