### PR TITLE
Use stdClass for claims objects to make sure they are serialized correctly

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -195,8 +195,8 @@ class LoginController extends BaseOidcController {
 			// https://openid.net/specs/openid-connect-core-1_0.html#IndividualClaimsRequests
 			// ['essential' => true] means it's mandatory but it won't trigger an error if it's not there
 			// null means we want it
-			'id_token' => [],
-			'userinfo' => [],
+			'id_token' => new \stdClass(),
+			'userinfo' => new \stdClass(),
 		];
 
 		$resolveNestedClaims = $this->providerService->getSetting($providerId, ProviderService::SETTING_RESOLVE_NESTED_AND_FALLBACK_CLAIMS_MAPPING, '0') === '1';
@@ -210,8 +210,8 @@ class LoginController extends BaseOidcController {
 			$quotaAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_QUOTA, 'quota');
 			$groupsAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_GROUPS, 'groups');
 			foreach ([$emailAttribute, $displaynameAttribute, $quotaAttribute, $groupsAttribute] as $claim) {
-				$claims['id_token'][$claim] = null;
-				$claims['userinfo'][$claim] = null;
+				$claims['id_token']->{$claim} = null;
+				$claims['userinfo']->{$claim} = null;
 			}
 		} else {
 			// No default claim, we only set the claims if an attribute is mapped
@@ -234,8 +234,8 @@ class LoginController extends BaseOidcController {
 
 			foreach ($rawClaims as $claim) {
 				if ($claim !== '') {
-					$claims['id_token'][$claim] = null;
-					$claims['userinfo'][$claim] = null;
+					$claims['id_token']->{$claim} = null;
+					$claims['userinfo']->{$claim} = null;
 				}
 			}
 		}
@@ -245,16 +245,16 @@ class LoginController extends BaseOidcController {
 			if ($resolveNestedClaims) {
 				$uidAttributeToRequest = trim(explode('|', $uidAttribute)[0]);
 			}
-			$claims['id_token'][$uidAttributeToRequest] = ['essential' => true];
-			$claims['userinfo'][$uidAttributeToRequest] = ['essential' => true];
+			$claims['id_token']->{$uidAttributeToRequest} = ['essential' => true];
+			$claims['userinfo']->{$uidAttributeToRequest} = ['essential' => true];
 		}
 
 		$extraClaimsString = $this->providerService->getSetting($providerId, ProviderService::SETTING_EXTRA_CLAIMS, '');
 		if ($extraClaimsString) {
 			$extraClaims = explode(' ', $extraClaimsString);
 			foreach ($extraClaims as $extraClaim) {
-				$claims['id_token'][$extraClaim] = null;
-				$claims['userinfo'][$extraClaim] = null;
+				$claims['id_token']->{$extraClaim} = null;
+				$claims['userinfo']->{$extraClaim} = null;
 			}
 		}
 


### PR DESCRIPTION
In some cases, the claim list is empty and the `claims` GET params gets serialized to 
`{"id_token":[],"userinfo":[]}`
instead of the expected
`{"id_token":{},"userinfo":{}}`
