### PR TITLE
feat: allow requesting scopes when using ExternalTokenRequestedEvent event

### DIFF
--- a/lib/Event/ExternalTokenRequestedEvent.php
+++ b/lib/Event/ExternalTokenRequestedEvent.php
@@ -18,8 +18,14 @@ class ExternalTokenRequestedEvent extends Event {
 
 	private ?Token $token = null;
 
-	public function __construct() {
+	public function __construct(
+		private string $extraScopes = '',
+	) {
 		parent::__construct();
+	}
+
+	public function getExtraScopes(): string {
+		return $this->extraScopes;
 	}
 
 	public function getToken(): ?Token {

--- a/lib/Listener/ExternalTokenRequestedListener.php
+++ b/lib/Listener/ExternalTokenRequestedListener.php
@@ -40,6 +40,7 @@ class ExternalTokenRequestedListener implements IEventListener {
 			return;
 		}
 
+		$extraScopes = $event->getExtraScopes();
 		$this->logger->debug('[ExternalTokenRequestedListener] received request');
 
 		$storeLoginTokenEnabled = $this->config->getAppValue(Application::APP_ID, 'store_login_token', '0') === '1';
@@ -47,7 +48,7 @@ class ExternalTokenRequestedListener implements IEventListener {
 			throw new GetExternalTokenFailedException('Failed to get external token, login token is not stored', 0);
 		}
 
-		$token = $this->tokenService->getToken();
+		$token = $this->tokenService->getToken(true, $extraScopes);
 		$event->setToken($token);
 	}
 }


### PR DESCRIPTION
Allow requesting scope when using ExternalTokenRequestedEvent event.

Usage:
```php
$scopes = "myscope1 myscope2";

$event = new ExternalTokenRequestedEvent($scopes);
```
Part of https://github.com/nextcloud/user_oidc/issues/1091