### PR TITLE
Issue-1100: Nested & Fallback Claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,40 @@ This app can stop matching users (when a user search is performed in Nextcloud) 
 ],
 ```
 
+### Optional: Enable support for nested and fallback claim mappings
+
+By default, claim mapping in this app uses **flat attribute keys** like `email`, `name`, `custom.nickname`, etc.
+However, some Identity Providers return **structured tokens** (nested JSON), and mapping such claims requires dot-notation (e.g. `custom.nickname` → `{ "custom": { "nickname": "value" } }`).
+
+Additionally, you may want to define **fallbacks**, in case a preferred claim is missing, using the `|` separator.
+
+#### Example
+
+```
+custom.nickname | profile.name | name
+```
+
+This will return the first non-empty string from the token in the order defined.
+
+
+#### Enabling this behavior (optional)
+
+To enable support for dot-notation and fallback claims for a specific provider, set the following configuration flag via the Nextcloud command line:
+
+```bash
+php occ user_oidc:provider <your-provider-identifier> --resolve-nested-claims=1
+```
+
+To disable again:
+
+```bash
+php occ user_oidc:provider <your-provider-identifier> --resolve-nested-claims=0
+```
+
+This setting is also available in the web interface when configuring a provider.
+This setting is **disabled by default** to ensure full backward compatibility with existing configurations and flat token structures.
+
+
 ## Building the app
 
 Requirements for building:

--- a/lib/Command/UpsertProvider.php
+++ b/lib/Command/UpsertProvider.php
@@ -143,6 +143,12 @@ class UpsertProvider extends Base {
 			'shortcut' => null, 'mode' => InputOption::VALUE_REQUIRED, 'setting_key' => ProviderService::SETTING_MAPPING_GROUPS,
 			'description' => 'Attribute mapping of the groups',
 		],
+		'resolve-nested-claims' => [
+			'shortcut' => null,
+			'mode' => InputOption::VALUE_REQUIRED,
+			'setting_key' => ProviderService::SETTING_RESOLVE_NESTED_AND_FALLBACK_CLAIMS_MAPPING,
+			'description' => 'Enable support for dot-separated and fallback claim mappings (e.g. "a.b | c.d | e"). 1 to enable, 0 to disable (default)',
+		],
 	];
 
 	public function __construct(

--- a/lib/Service/ProviderService.php
+++ b/lib/Service/ProviderService.php
@@ -51,6 +51,7 @@ class ProviderService {
 	public const SETTING_GROUP_PROVISIONING = 'groupProvisioning';
 	public const SETTING_GROUP_WHITELIST_REGEX = 'groupWhitelistRegex';
 	public const SETTING_RESTRICT_LOGIN_TO_GROUPS = 'restrictLoginToGroups';
+	public const SETTING_RESOLVE_NESTED_AND_FALLBACK_CLAIMS_MAPPING = 'nestedAndFallbackClaims';
 
 	public const BOOLEAN_SETTINGS_DEFAULT_VALUES = [
 		self::SETTING_GROUP_PROVISIONING => false,
@@ -60,6 +61,7 @@ class ProviderService {
 		self::SETTING_CHECK_BEARER => false,
 		self::SETTING_SEND_ID_TOKEN_HINT => false,
 		self::SETTING_RESTRICT_LOGIN_TO_GROUPS => false,
+		self::SETTING_RESOLVE_NESTED_AND_FALLBACK_CLAIMS_MAPPING => false,
 	];
 
 	public function __construct(
@@ -168,6 +170,7 @@ class ProviderService {
 			self::SETTING_GROUP_PROVISIONING,
 			self::SETTING_GROUP_WHITELIST_REGEX,
 			self::SETTING_RESTRICT_LOGIN_TO_GROUPS,
+			self::SETTING_RESOLVE_NESTED_AND_FALLBACK_CLAIMS_MAPPING,
 		];
 	}
 

--- a/lib/User/Backend.php
+++ b/lib/User/Backend.php
@@ -17,6 +17,7 @@ use OCA\UserOIDC\Event\TokenValidatedEvent;
 use OCA\UserOIDC\Service\DiscoveryService;
 use OCA\UserOIDC\Service\LdapService;
 use OCA\UserOIDC\Service\ProviderService;
+use OCA\UserOIDC\Service\ProvisioningService;
 use OCA\UserOIDC\User\Validator\SelfEncodedValidator;
 use OCA\UserOIDC\User\Validator\UserInfoValidator;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -56,6 +57,7 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 		private DiscoveryService $discoveryService,
 		private ProviderMapper $providerMapper,
 		private ProviderService $providerService,
+		private ProvisioningService $provisioningService,
 		private LdapService $ldapService,
 		private IUserManager $userManager,
 	) {
@@ -175,22 +177,21 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 		$result = ['formatted' => [], 'raw' => $attributes];
 
 		$emailAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_EMAIL, 'email');
-		$result['formatted']['email'] = $attributes[$emailAttribute] ?? null;
+		$result['formatted']['email'] = $this->provisioningService->getClaimValue($attributes, $emailAttribute, $providerId);
 
 		$displaynameAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_DISPLAYNAME, 'name');
-		$result['formatted']['displayName'] = $attributes[$displaynameAttribute] ?? null;
-
+		$result['formatted']['displayName'] = $this->provisioningService->getClaimValue($attributes, $displaynameAttribute, $providerId);
 		$quotaAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_QUOTA, 'quota');
-		$result['formatted']['quota'] = $attributes[$quotaAttribute] ?? null;
+		$result['formatted']['quota'] = $this->provisioningService->getClaimValue($attributes, $quotaAttribute, $providerId);
 		if ($result['formatted']['quota'] === '') {
 			$result['formatted']['quota'] = 'default';
 		}
 
 		$groupsAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_GROUPS, 'groups');
-		$result['formatted']['groups'] = $attributes[$groupsAttribute] ?? null;
+		$result['formatted']['groups'] = $this->provisioningService->getClaimValue($attributes, $groupsAttribute, $providerId);
 
 		$uidAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_UID, 'sub');
-		$result['formatted']['uid'] = $attributes[$uidAttribute] ?? null;
+		$result['formatted']['uid'] = $this->provisioningService->getClaimValue($attributes, $uidAttribute, $providerId);
 
 		return $result;
 	}

--- a/lib/User/Validator/UserInfoValidator.php
+++ b/lib/User/Validator/UserInfoValidator.php
@@ -12,23 +12,24 @@ namespace OCA\UserOIDC\User\Validator;
 use OCA\UserOIDC\Db\Provider;
 use OCA\UserOIDC\Service\OIDCService;
 use OCA\UserOIDC\Service\ProviderService;
+use OCA\UserOIDC\Service\ProvisioningService;
 
 class UserInfoValidator implements IBearerTokenValidator {
 
 	public function __construct(
 		private OIDCService $userInfoService,
 		private ProviderService $providerService,
+		private ProvisioningService $provisioningService,
 	) {
 	}
 
 	public function isValidBearerToken(Provider $provider, string $bearerToken): ?string {
 		$userInfo = $this->userInfoService->userinfo($provider, $bearerToken);
-		$uidAttribute = $this->providerService->getSetting($provider->getId(), ProviderService::SETTING_MAPPING_UID, ProviderService::SETTING_MAPPING_UID_DEFAULT);
-		if (!isset($userInfo[$uidAttribute])) {
-			return null;
-		}
-
-		return $userInfo[$uidAttribute];
+		$providerId = $provider->getId();
+		$uidAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_UID, ProviderService::SETTING_MAPPING_UID_DEFAULT);
+		// find the user ID
+		$uid = $this->provisioningService->getClaimValue($userInfo, $uidAttribute, $providerId);
+		return $uid ?: null;
 	}
 
 	public function getProvisioningStrategy(): string {

--- a/src/components/SettingsForm.vue
+++ b/src/components/SettingsForm.vue
@@ -67,6 +67,9 @@
 				placeholder="claim1 claim2 claim3">
 		</p>
 		<h3><b>{{ t('user_oidc', 'Attribute mapping') }}</b></h3>
+		<NcCheckboxRadioSwitch :checked.sync="localProvider.settings.nestedAndFallbackClaims" wrapper-element="div">
+			{{ t('user_oidc', 'Enable nested and fallback claim mappings (like "{example}")', { example: 'custom.nickname | profile.name | name' }) }}
+		</NcCheckboxRadioSwitch>
 		<p>
 			<label for="mapping-uid">{{ t('user_oidc', 'User ID mapping') }}</label>
 			<input id="mapping-uid"

--- a/tests/unit/Service/ProviderServiceTest.php
+++ b/tests/unit/Service/ProviderServiceTest.php
@@ -92,6 +92,7 @@ class ProviderServiceTest extends TestCase {
 					'groupProvisioning' => true,
 					'groupWhitelistRegex' => '1',
 					'restrictLoginToGroups' => true,
+					'nestedAndFallbackClaims' => true,
 				],
 			],
 			[
@@ -133,6 +134,7 @@ class ProviderServiceTest extends TestCase {
 					'groupProvisioning' => true,
 					'groupWhitelistRegex' => '1',
 					'restrictLoginToGroups' => true,
+					'nestedAndFallbackClaims' => true,
 				],
 			],
 		], $this->providerService->getProvidersWithSettings());
@@ -171,6 +173,7 @@ class ProviderServiceTest extends TestCase {
 			'mappingGender' => 'gender',
 			'groupWhitelistRegex' => '',
 			'restrictLoginToGroups' => false,
+			'nestedAndFallbackClaims' => false,
 		];
 		$this->config->expects(self::any())
 			->method('getAppValue')
@@ -206,6 +209,7 @@ class ProviderServiceTest extends TestCase {
 				[Application::APP_ID, 'provider-1-' . ProviderService::SETTING_GROUP_PROVISIONING, '', '1'],
 				[Application::APP_ID, 'provider-1-' . ProviderService::SETTING_GROUP_WHITELIST_REGEX, '', ''],
 				[Application::APP_ID, 'provider-1-' . ProviderService::SETTING_RESTRICT_LOGIN_TO_GROUPS, '', '0'],
+				[Application::APP_ID, 'provider-1-' . ProviderService::SETTING_RESOLVE_NESTED_AND_FALLBACK_CLAIMS_MAPPING, '', '0'],
 			]);
 
 		Assert::assertEquals(

--- a/tests/unit/Service/ProvisioningServiceTest.php
+++ b/tests/unit/Service/ProvisioningServiceTest.php
@@ -143,6 +143,7 @@ class ProvisioningServiceTest extends TestCase {
 					[$providerId, ProviderService::SETTING_MAPPING_BIOGRAPHY, 'biography', 'biography'],
 					[$providerId, ProviderService::SETTING_MAPPING_PHONE, 'phone_number', 'phone_number'],
 					[$providerId, ProviderService::SETTING_MAPPING_GENDER, 'gender', 'gender'],
+					[$providerId, ProviderService::SETTING_RESOLVE_NESTED_AND_FALLBACK_CLAIMS_MAPPING, '0', '0'],
 				]
 			));
 
@@ -214,6 +215,7 @@ class ProvisioningServiceTest extends TestCase {
 					[$providerId, ProviderService::SETTING_MAPPING_BIOGRAPHY, 'biography', 'biography'],
 					[$providerId, ProviderService::SETTING_MAPPING_PHONE, 'phone_number', 'phone_number'],
 					[$providerId, ProviderService::SETTING_MAPPING_GENDER, 'gender', 'gender'],
+					[$providerId, ProviderService::SETTING_RESOLVE_NESTED_AND_FALLBACK_CLAIMS_MAPPING, '0', '0'],
 				]
 			));
 
@@ -257,7 +259,7 @@ class ProvisioningServiceTest extends TestCase {
 			->method('getProperty')
 			->with('twitter')
 			->willReturn($property);
-		
+
 
 		$this->accountManager->expects(self::once())
 			->method('getAccount')


### PR DESCRIPTION
As described in Issue-1100 there is current no possibility to mappe values which are nested in other the the root scope. To enable this we change the way how Mapping-Attributes are used. They should understand the . as object seperator.

Sometimes you like to have a fallback in your mappings. So for displayname for example please take the nickname (if it exists), if it does not exists take the full name .... To support this, we change the way how Mapping-Attributes are used. They should understand the | as an alternative mapping.

WIP: Testing need to be done still fully, I dont know if I changed everything needed but on my side it works.

#1100  