### PR TITLE
Make settings form footer sticky

### DIFF
--- a/src/components/SettingsForm.vue
+++ b/src/components/SettingsForm.vue
@@ -360,6 +360,9 @@ export default {
 		display: flex;
 		justify-content: right;
 		padding: 8px 0;
+		position: sticky;
+		bottom: 0;
+		background-color: var(--color-main-background);
 		> * {
 			margin: 0 4px;
 		}


### PR DESCRIPTION
To avoid having to scroll down to find the ok/cancel buttons, the footer is now sticky at the bottom.

![image](https://github.com/user-attachments/assets/c63d5335-dbd6-4d73-b2df-40cc46a51373)
