### PR TITLE
Add optional provider-specific post_logout_uri setting

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 	<name>OpenID Connect user backend</name>
 	<summary>Use an OpenID Connect backend to login to your Nextcloud</summary>
 	<description>Allows flexible configuration of an OIDC server as Nextcloud login user backend.</description>
-	<version>7.4.0</version>
+	<version>7.5.0</version>
 	<licence>agpl</licence>
 	<author>Roeland Jago Douma</author>
 	<author>Julius Härtl</author>

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -656,7 +656,6 @@ class LoginController extends BaseOidcController {
 	public function singleLogoutService() {
 		// TODO throttle in all failing cases
 		$oidcSystemConfig = $this->config->getSystemValue('user_oidc', []);
-		$targetUrl = $this->urlGenerator->getAbsoluteURL('/');
 		if (!isset($oidcSystemConfig['single_logout']) || $oidcSystemConfig['single_logout']) {
 			$isFromGS = ($this->config->getSystemValueBool('gs.enabled', false)
 				&& $this->config->getSystemValueString('gss.mode', '') === 'master');
@@ -697,6 +696,7 @@ class LoginController extends BaseOidcController {
 				$endSessionEndpoint = $customEndSessionEndpoint ?: $defaultEndSessionEndpoint;
 
 				if ($endSessionEndpoint) {
+					$targetUrl = $provider->getPostLogoutUri() ?: $this->urlGenerator->getAbsoluteURL('/');
 					$endSessionEndpoint .= '?post_logout_redirect_uri=' . $targetUrl;
 					$endSessionEndpoint .= '&client_id=' . $provider->getClientId();
 					$shouldSendIdToken = $this->providerService->getSetting(

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -78,7 +78,8 @@ class SettingsController extends Controller {
 
 	#[PasswordConfirmationRequired]
 	public function createProvider(string $identifier, string $clientId, string $clientSecret, string $discoveryEndpoint,
-		array $settings = [], string $scope = 'openid email profile', ?string $endSessionEndpoint = null): JSONResponse {
+		array $settings = [], string $scope = 'openid email profile', ?string $endSessionEndpoint = null,
+		?string $postLogoutUri = null): JSONResponse {
 		if ($this->providerService->getProviderByIdentifier($identifier) !== null) {
 			return new JSONResponse(['message' => 'Provider with the given identifier already exists'], Http::STATUS_CONFLICT);
 		}
@@ -99,6 +100,7 @@ class SettingsController extends Controller {
 		$provider->setClientSecret($encryptedClientSecret);
 		$provider->setDiscoveryEndpoint($discoveryEndpoint);
 		$provider->setEndSessionEndpoint($endSessionEndpoint ?: null);
+		$provider->setPostLogoutUri($postLogoutUri ?: null);
 		$provider->setScope($scope);
 		$provider = $this->providerMapper->insert($provider);
 
@@ -109,7 +111,8 @@ class SettingsController extends Controller {
 
 	#[PasswordConfirmationRequired]
 	public function updateProvider(int $providerId, string $identifier, string $clientId, string $discoveryEndpoint, ?string $clientSecret = null,
-		array $settings = [], string $scope = 'openid email profile', ?string $endSessionEndpoint = null): JSONResponse {
+		array $settings = [], string $scope = 'openid email profile', ?string $endSessionEndpoint = null,
+		?string $postLogoutUri = null): JSONResponse {
 		$provider = $this->providerMapper->getProvider($providerId);
 
 		if ($this->providerService->getProviderByIdentifier($identifier) === null) {
@@ -133,6 +136,7 @@ class SettingsController extends Controller {
 		}
 		$provider->setDiscoveryEndpoint($discoveryEndpoint);
 		$provider->setEndSessionEndpoint($endSessionEndpoint ?: null);
+		$provider->setPostLogoutUri($postLogoutUri ?: null);
 		$provider->setScope($scope);
 		$provider = $this->providerMapper->update($provider);
 

--- a/lib/Db/Provider.php
+++ b/lib/Db/Provider.php
@@ -21,30 +21,24 @@ use OCP\AppFramework\Db\Entity;
  * @method \void setDiscoveryEndpoint(?string $discoveryEndpoint)
  * @method \string|\null getEndSessionEndpoint()
  * @method \void setEndSessionEndpoint(?string $endSessionEndpoint)
- * @method \string getPostLogoutUri()
- * @method \void setPostLogoutUri(string $postLogoutUri)
+ * @method \string|\null getPostLogoutUri()
+ * @method \void setPostLogoutUri(?string $postLogoutUri)
  * @method \void setScope(string $scope)
  */
 class Provider extends Entity implements \JsonSerializable {
 
 	/** @var string */
 	protected $identifier;
-
 	/** @var string */
 	protected $clientId;
-
 	/** @var string */
 	protected $clientSecret;
-
 	/** @var ?string */
 	protected $discoveryEndpoint;
-
 	/** @var ?string */
 	protected $endSessionEndpoint;
-
 	/** @var string */
 	protected $postLogoutUri;
-
 	/** @var string */
 	protected $scope;
 
@@ -58,12 +52,12 @@ class Provider extends Entity implements \JsonSerializable {
 	#[\ReturnTypeWillChange]
 	public function jsonSerialize() {
 		return [
-			'id' => $this->id,
-			'identifier' => $this->identifier,
-			'clientId' => $this->clientId,
-			'discoveryEndpoint' => $this->discoveryEndpoint,
-			'endSessionEndpoint' => $this->endSessionEndpoint,
-			'postLogoutUri' => $this->postLogoutUri,
+			'id' => $this->getId(),
+			'identifier' => $this->getIdentifier(),
+			'clientId' => $this->getClientId(),
+			'discoveryEndpoint' => $this->getDiscoveryEndpoint(),
+			'endSessionEndpoint' => $this->getEndSessionEndpoint(),
+			'postLogoutUri' => $this->getPostLogoutUri(),
 			'scope' => trim($this->getScope()),
 		];
 	}

--- a/lib/Db/Provider.php
+++ b/lib/Db/Provider.php
@@ -21,6 +21,8 @@ use OCP\AppFramework\Db\Entity;
  * @method \void setDiscoveryEndpoint(?string $discoveryEndpoint)
  * @method \string|\null getEndSessionEndpoint()
  * @method \void setEndSessionEndpoint(?string $endSessionEndpoint)
+ * @method \string getPostLogoutUri()
+ * @method \void setPostLogoutUri(string $postLogoutUri)
  * @method \void setScope(string $scope)
  */
 class Provider extends Entity implements \JsonSerializable {
@@ -41,6 +43,9 @@ class Provider extends Entity implements \JsonSerializable {
 	protected $endSessionEndpoint;
 
 	/** @var string */
+	protected $postLogoutUri;
+
+	/** @var string */
 	protected $scope;
 
 	/**
@@ -58,6 +63,7 @@ class Provider extends Entity implements \JsonSerializable {
 			'clientId' => $this->clientId,
 			'discoveryEndpoint' => $this->discoveryEndpoint,
 			'endSessionEndpoint' => $this->endSessionEndpoint,
+			'postLogoutUri' => $this->postLogoutUri,
 			'scope' => trim($this->getScope()),
 		];
 	}

--- a/lib/Db/ProviderMapper.php
+++ b/lib/Db/ProviderMapper.php
@@ -83,14 +83,15 @@ class ProviderMapper extends QBMapper {
 	 * @param string|null $discoveryuri
 	 * @param string $scope
 	 * @param string|null $endsessionendpointuri
+	 * @param string|null $postLogoutUri
 	 * @return Provider|Entity
 	 * @throws DoesNotExistException
-	 * @throws MultipleObjectsReturnedException
 	 * @throws Exception
+	 * @throws MultipleObjectsReturnedException
 	 */
 	public function createOrUpdateProvider(string $identifier, ?string $clientid = null,
 		?string $clientsecret = null, ?string $discoveryuri = null, string $scope = 'openid email profile',
-		?string $endsessionendpointuri = null) {
+		?string $endsessionendpointuri = null, ?string $postLogoutUri = null) {
 		try {
 			$provider = $this->findProviderByIdentifier($identifier);
 		} catch (DoesNotExistException $eNotExist) {
@@ -107,6 +108,7 @@ class ProviderMapper extends QBMapper {
 			$provider->setClientSecret($clientsecret);
 			$provider->setDiscoveryEndpoint($discoveryuri);
 			$provider->setEndSessionEndpoint($endsessionendpointuri);
+			$provider->setPostLogoutUri($postLogoutUri);
 			$provider->setScope($scope);
 			return $this->insert($provider);
 		} else {
@@ -121,6 +123,9 @@ class ProviderMapper extends QBMapper {
 			}
 			if ($endsessionendpointuri !== null) {
 				$provider->setEndSessionEndpoint($endsessionendpointuri ?: null);
+			}
+			if ($postLogoutUri !== null) {
+				$provider->setPostLogoutUri($postLogoutUri ?: null);
 			}
 			$provider->setScope($scope);
 			return $this->update($provider);

--- a/lib/Migration/Version070300Date20250515141105.php
+++ b/lib/Migration/Version070300Date20250515141105.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\UserOIDC\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+/**
+ * Auto-generated migration step: Please modify to your needs!
+ */
+class Version070300Date20250515141105 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		if ($schema->hasTable('user_oidc_providers')) {
+			$table = $schema->getTable('user_oidc_providers');
+			if (!$table->hasColumn('post_logout_uri')) {
+				$table->addColumn('post_logout_uri', Types::STRING, [
+					'notnull' => false,
+					'length' => 255,
+				]);
+				return $schema;
+			}
+		}
+
+		return null;
+	}
+}

--- a/lib/Migration/Version070500Date20250515141105.php
+++ b/lib/Migration/Version070500Date20250515141105.php
@@ -18,7 +18,7 @@ use OCP\Migration\SimpleMigrationStep;
 /**
  * Auto-generated migration step: Please modify to your needs!
  */
-class Version070300Date20250515141105 extends SimpleMigrationStep {
+class Version070500Date20250515141105 extends SimpleMigrationStep {
 	/**
 	 * @param IOutput $output
 	 * @param Closure $schemaClosure

--- a/src/components/AdminSettings.vue
+++ b/src/components/AdminSettings.vue
@@ -198,6 +198,7 @@ export default {
 				clientSecret: '',
 				discoveryEndpoint: '',
 				endSessionEndpoint: '',
+				postLogoutUri: '',
 				settings: {
 					uniqueUid: true,
 					checkBearer: false,
@@ -323,6 +324,7 @@ export default {
 				this.newProvider.clientSecret = ''
 				this.newProvider.discoveryEndpoint = ''
 				this.newProvider.endSessionEndpoint = ''
+				this.newProvider.postLogoutUri = ''
 				this.showNewProvider = false
 			} catch (error) {
 				logger.error('Could not register a provider: ' + error.message, { error })

--- a/src/components/SettingsForm.vue
+++ b/src/components/SettingsForm.vue
@@ -53,6 +53,15 @@
 				placeholder="(Optional)">
 		</p>
 		<p>
+			<label for="oidc-post-logout-uri">{{ t('user_oidc', 'Post logout URI') }}</label>
+			<input id="oidc-post-logout-uri"
+				v-model="localProvider.postLogoutUri"
+				class="italic-placeholder"
+				type="text"
+				maxlength="255"
+				placeholder="(Optional)">
+		</p>
+		<p>
 			<label for="oidc-scope">{{ t('user_oidc', 'Scope') }}</label>
 			<input id="oidc-scope"
 				v-model="localProvider.scope"

--- a/tests/unit/Service/ProviderServiceTest.php
+++ b/tests/unit/Service/ProviderServiceTest.php
@@ -59,6 +59,7 @@ class ProviderServiceTest extends TestCase {
 				'clientId' => null,
 				'discoveryEndpoint' => null,
 				'endSessionEndpoint' => null,
+				'postLogoutUri' => null,
 				'scope' => null,
 				'settings' => [
 					'mappingDisplayName' => '1',
@@ -103,6 +104,7 @@ class ProviderServiceTest extends TestCase {
 				'clientId' => null,
 				'discoveryEndpoint' => null,
 				'endSessionEndpoint' => null,
+				'postLogoutUri' => null,
 				'scope' => null,
 				'settings' => [
 					'mappingDisplayName' => '1',


### PR DESCRIPTION
Pass this value as a GET param to the end_session_endpoint. If supported by the IdP, the user is redirected to this URI after logging out.

The new setting is just below the end session endpoint in the provider settings form:

![image](https://github.com/user-attachments/assets/213a95b5-2edc-405b-95dd-1df9358854d0)


closes #1115 #993