### PR TITLE
chore(tests): Cleanup bootstrap.php to be forward-compatible

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,9 +26,6 @@ jobs:
         include:
             - php-versions: 8.1
               databases: mysql
-              server-versions: stable28
-            - php-versions: 8.1
-              databases: mysql
               server-versions: stable29
             - php-versions: 8.1
               databases: mysql

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         php-versions: ['8.0', '8.1', '8.2']
         databases: ['mysql']
-        server-versions: ['stable28', 'stable29', 'stable30', 'stable31', 'master']
+        server-versions: ['stable29', 'stable30', 'stable31', 'master']
         exclude:
           - php-versions: 8.0
             server-versions: master
@@ -32,9 +32,6 @@ jobs:
           - php-versions: 8.0
             server-versions: stable30
         include:
-          - php-versions: 8.3
-            databases: mysql
-            server-versions: stable28
           - php-versions: 8.3
             databases: mysql
             server-versions: stable29

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,17 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * SPDX-FileCopyrightText: 2016 Nextcloud GmbH and Nextcloud contributors
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+use OCP\App\IAppManager;
+use OCP\Server;
+
 if (!defined('PHPUNIT_RUN')) {
 	define('PHPUNIT_RUN', 1);
 }
+
 require_once __DIR__ . '/../../../lib/base.php';
+require_once __DIR__ . '/../../../tests/autoload.php';
 require_once __DIR__ . '/../vendor/autoload.php';
 
-\OC::$loader->addValidRoot(OC::$SERVERROOT . '/tests');
-\OC_App::loadApp('user_oidc');
+Server::get(IAppManager::class)->loadApp('user_oidc');
 
 OC_Hook::clear();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,5 +19,3 @@ require_once __DIR__ . '/../../../tests/autoload.php';
 require_once __DIR__ . '/../vendor/autoload.php';
 
 Server::get(IAppManager::class)->loadApp('user_oidc');
-
-OC_Hook::clear();


### PR DESCRIPTION
This uses the new tests/autoload.php from nextcloud/server instead of messing directly with OC private autoloader.

See https://github.com/nextcloud/server/pull/52951 and https://github.com/nextcloud/server/pull/52945 for context.