### PR TITLE
Set the gss session data in the controller rather than in the service

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -533,7 +533,9 @@ class LoginController extends BaseOidcController {
 				return $this->build403TemplateResponse($message, Http::STATUS_BAD_REQUEST, ['reason' => 'non-soft auto provision, user conflict'], false);
 			}
 			// use potential user from other backend, create it in our backend if it does not exist
-			$user = $this->provisioningService->provisionUser($userId, $providerId, $idTokenPayload, $userFromOtherBackend);
+			$provisioningResult = $this->provisioningService->provisionUser($userId, $providerId, $idTokenPayload, $userFromOtherBackend);
+			$user = $provisioningResult['user'];
+			$this->session->set('user_oidc.oidcUserData', $provisioningResult['userData']);
 		} else {
 			// when auto provision is disabled, we assume the user has been created by another user backend (or manually)
 			$user = $userFromOtherBackend;

--- a/lib/User/Provisioning/SelfEncodedTokenProvisioning.php
+++ b/lib/User/Provisioning/SelfEncodedTokenProvisioning.php
@@ -34,6 +34,7 @@ class SelfEncodedTokenProvisioning implements IProvisioningStrategy {
 			return null;
 		}
 
-		return $this->provisioningService->provisionUser($tokenUserId, $provider->getId(), $payload, $userFromOtherBackend);
+		$provisioningResult = $this->provisioningService->provisionUser($tokenUserId, $provider->getId(), $payload, $userFromOtherBackend);
+		return $provisioningResult['user'];
 	}
 }


### PR DESCRIPTION
I don't even know how it worked when setting it in the provisioning service.

The logic is now to return the user data from  `ProvisioningService::provisionUser` and set the session value (that will be used by gss master) in the controller.