### PR TITLE
Improve the NC error page when the IdP auth fails

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -310,10 +310,15 @@ class LoginController extends BaseOidcController {
 		$this->logger->debug('Code login with core: ' . $code . ' and state: ' . $state);
 
 		if ($error !== '') {
-			return new JSONResponse([
-				'error' => $error,
-				'error_description' => $error_description,
-			], Http::STATUS_FORBIDDEN);
+			$this->logger->warning('Code login error', ['error' => $error, 'error_description' => $error_description]);
+			if ($this->isDebugModeEnabled()) {
+				return new JSONResponse([
+					'error' => $error,
+					'error_description' => $error_description,
+				], Http::STATUS_FORBIDDEN);
+			}
+			$message = $this->l10n->t('The identity provider failed to authenticate the user.');
+			return $this->build403TemplateResponse($message, Http::STATUS_BAD_REQUEST, [], false);
 		}
 
 		if ($this->session->get(self::STATE) !== $state) {


### PR DESCRIPTION
When the IdP redirects to the user_oidc "code" endpoint with an error, we used to display a raw JSON response. We can return a real error page there with a nicer user-facing error description. The real error is logged with a "warning" level.

Since 32, the "403" template contains a button to go back to the login page. Even better for us.