### PR TITLE
Support nested claim mapping for groups attribute

### DIFF
--- a/lib/Service/ProvisioningService.php
+++ b/lib/Service/ProvisioningService.php
@@ -62,9 +62,9 @@ class ProvisioningService {
 
 	/**
 	 * Resolves a claim path like "custom.nickname" or multiple alternatives separated by "|".
-	 * Returns the first found string value, or null if none could be resolved.
+	 * Returns the first found value, or null if none could be resolved.
 	 */
-	public function getClaimValue(object|array $tokenPayload, string $claimPath, int $providerId): mixed {
+	public function getClaimValues(object|array $tokenPayload, string $claimPath, int $providerId): mixed {
 		if ($claimPath === '') {
 			return null;
 		}
@@ -99,12 +99,19 @@ class ProvisioningService {
 				}
 			}
 
-			if (is_string($value)) {
-				return $value;
-			}
+			return $value;
 		}
 
 		return null;
+	}
+
+	/**
+	 * Resolves a claim path like "custom.nickname" or multiple alternatives separated by "|".
+	 * Returns the first found string value, or null if none could be resolved.
+	 */
+	public function getClaimValue(object|array $tokenPayload, string $claimPath, int $providerId): mixed {
+		$value = $this->getClaimValues($tokenPayload, $claimPath, $providerId);
+		return is_string($value) ? $value : null;
 	}
 
 	/**
@@ -523,7 +530,7 @@ class ProvisioningService {
 
 	public function getSyncGroupsOfToken(int $providerId, object $idTokenPayload) {
 		$groupsAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_GROUPS, 'groups');
-		$groupsData = $idTokenPayload->{$groupsAttribute} ?? null;
+		$groupsData = $this->getClaimValues($idTokenPayload, $groupsAttribute, $providerId);
 
 		$groupsWhitelistRegex = $this->getGroupWhitelistRegex($providerId);
 

--- a/tests/unit/Service/ProvisioningServiceTest.php
+++ b/tests/unit/Service/ProvisioningServiceTest.php
@@ -360,6 +360,7 @@ class ProvisioningServiceTest extends TestCase {
 				[
 					[$providerId, ProviderService::SETTING_GROUP_WHITELIST_REGEX, '', $group_whitelist],
 					[$providerId, ProviderService::SETTING_MAPPING_GROUPS, 'groups', 'groups'],
+					[$providerId, ProviderService::SETTING_RESOLVE_NESTED_AND_FALLBACK_CLAIMS_MAPPING, '0', '0'],
 				]
 			));
 


### PR DESCRIPTION
The provider option "Enable nested and fallback claim mappings" recently introduced in #1103 currently doesn't work for the groups attribute mapping since `getSyncGroupsOfToken` uses `$groupsAttribute` for directly accessing properties inside `$idTokenPayload` (instead of using `getClaimValue` to allow for dot-notation resolution).

This is unfortunate because some identity providers, such as Keycloak, nest user roles inside the ID token (e.g., under `realm_access.roles` for Keycloak realm-level and `resource_access.${client_id}.roles` for Keycloak client-level roles).

My PR fixes the issue by adding the method `getClaimValues` and using it inside of `getSyncGroupsOfToken`. `getClaimValues` includes most of the logic of `getClaimValue`, but allows returning non-string values. The original behavior of `getClaimValue` is retained.

Closes #799.

