### PR TITLE
feat: allow self-signed SSL verification and support for oidc prompt

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -40,3 +40,4 @@
 - Thibault Coupin <thibault.coupin@gmail.com>
 - Tobias Wolter <towo@towo.eu>
 - Vincent Petry <vincent@nextcloud.com>
+- Elvis Yerel Roman Concha <yerel9212@yahoo.es>

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ for a proper jumpstart.
 'httpclient.allowselfsigned' => true,
 ```
 
-This configuration allows Nextcloud to **trust self-signed SSL certificates** when making HTTP requests through the internal HTTP client. It is especially useful when your OAuth2 or OIDC provider is hosted locally or uses a self-signed certificate not recognized by public CAs.
+This configuration allows Nextcloud to **trust self-signed SSL certificates** when making HTTP requests through the internal HTTP client.
+It is especially useful when your OAuth2 or OIDC provider is hosted locally or uses a self-signed certificate not recognized by public CAs.
 
-* **true**: Disables SSL certificate verification (`verify => false`)
+* **true**: Disables SSL certificate verification (adds the `verify => false` option to the actual HTTP client)
 * **false** (default): SSL verification remains enabled and strict
 
 > ⚠️ Use with caution in production environments, as disabling certificate verification can introduce security risks.
@@ -46,7 +47,8 @@ Supported values include:
 * `consent`
 * `internal` (custom)
 
-The `internal` prompt is specific to **[OAuth2 Passport Server](https://github.com/elyerr/oauth2-passport-server)** and is designed to enable seamless login for private or internal applications without requiring user consent or interaction.
+The `internal` prompt is specific to **[OAuth2 Passport Server](https://github.com/elyerr/oauth2-passport-server)** and is designed to enable seamless login
+for private or internal applications without requiring user consent or interaction.
 
 Documentation for all supported prompt values is available here:
 [Oauth2 passport server prompts-supported](https://gitlab.com/elyerr/oauth2-passport-server/-/wikis/home/prompts-supported)

--- a/README.md
+++ b/README.md
@@ -12,6 +12,47 @@ OpenID Connect user backend for Nextcloud
 See [Nextcloud and OpenID-Connect](https://web.archive.org/web/20240412121655/https://www.schiessle.org/articles/2023/07/04/nextcloud-and-openid-connect/)
 for a proper jumpstart.
 
+---
+
+## `httpclient.allowselfsigned`
+
+```php
+'httpclient.allowselfsigned' => true,
+```
+
+This configuration allows Nextcloud to **trust self-signed SSL certificates** when making HTTP requests through the internal HTTP client. It is especially useful when your OAuth2 or OIDC provider is hosted locally or uses a self-signed certificate not recognized by public CAs.
+
+* **true**: Disables SSL certificate verification (`verify => false`)
+* **false** (default): SSL verification remains enabled and strict
+
+> ⚠️ Use with caution in production environments, as disabling certificate verification can introduce security risks.
+
+---
+
+## `user_oidc.prompt`
+
+```php
+'user_oidc' => [
+  'prompt' => 'internal'
+]
+```
+
+This option allows customizing the `prompt` parameter sent in the OAuth2/OIDC authorization request.
+
+Supported values include:
+
+* `none`
+* `login`
+* `consent`
+* `internal` (custom)
+
+The `internal` prompt is specific to **[OAuth2 Passport Server](https://github.com/elyerr/oauth2-passport-server)** and is designed to enable seamless login for private or internal applications without requiring user consent or interaction.
+
+Documentation for all supported prompt values is available here:
+[Oauth2 passport server prompts-supported](https://gitlab.com/elyerr/oauth2-passport-server/-/wikis/home/prompts-supported)
+
+---
+
 ### User IDs
 
 The OpenID Connect backend will ensure that user ids are unique even when multiple providers would report the same user

--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ for a proper jumpstart.
 
 ---
 
-## `httpclient.allowselfsigned`
+## `user_oidc.httpclient.allowselfsigned`
 
 ```php
-'httpclient.allowselfsigned' => true,
+'user_oidc' => [
+    'httpclient.allowselfsigned' => true,
+]
 ```
 
 This configuration allows Nextcloud to **trust self-signed SSL certificates** when making HTTP requests through the internal HTTP client.

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6ec5b146c0205f89df6c9883eab66a38",
+    "content-hash": "1879aca685c182293d8b9e124cfc0946",
     "packages": [
         {
             "name": "bamarni/composer-bin-plugin",
@@ -460,21 +460,21 @@
         },
         {
             "name": "nextcloud/coding-standard",
-            "version": "v1.3.2",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud/coding-standard.git",
-                "reference": "9c719c4747fa26efc12f2e8b21c14a9a75c6ba6d"
+                "reference": "8e06808c1423e9208d63d1bd205b9a38bd400011"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud/coding-standard/zipball/9c719c4747fa26efc12f2e8b21c14a9a75c6ba6d",
-                "reference": "9c719c4747fa26efc12f2e8b21c14a9a75c6ba6d",
+                "url": "https://api.github.com/repos/nextcloud/coding-standard/zipball/8e06808c1423e9208d63d1bd205b9a38bd400011",
+                "reference": "8e06808c1423e9208d63d1bd205b9a38bd400011",
                 "shasum": ""
             },
             "require": {
                 "kubawerlos/php-cs-fixer-custom-fixers": "^3.22",
-                "php": "^7.3|^8.0",
+                "php": "^8.0",
                 "php-cs-fixer/shim": "^3.17"
             },
             "type": "library",
@@ -494,11 +494,14 @@
                 }
             ],
             "description": "Nextcloud coding standards for the php cs fixer",
+            "keywords": [
+                "dev"
+            ],
             "support": {
                 "issues": "https://github.com/nextcloud/coding-standard/issues",
-                "source": "https://github.com/nextcloud/coding-standard/tree/v1.3.2"
+                "source": "https://github.com/nextcloud/coding-standard/tree/v1.4.0"
             },
-            "time": "2024-10-14T16:49:05+00:00"
+            "time": "2025-06-19T12:27:27+00:00"
         },
         {
             "name": "nextcloud/ocp",
@@ -2696,8 +2699,5 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
-    "platform-overrides": {
-        "php": "8.0"
-    },
     "plugin-api-version": "2.6.0"
 }

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -56,8 +56,7 @@ use OCP\User\Events\UserLoggedInEvent;
 use Psr\Log\LoggerInterface;
 use UnexpectedValueException;
 
-class LoginController extends BaseOidcController
-{
+class LoginController extends BaseOidcController {
 	private const STATE = 'oidc.state';
 	private const NONCE = 'oidc.nonce';
 	public const PROVIDERID = 'oidc.providerid';
@@ -95,8 +94,7 @@ class LoginController extends BaseOidcController
 	/**
 	 * @return bool
 	 */
-	private function isSecure(): bool
-	{
+	private function isSecure(): bool {
 		// no restriction in debug mode
 		return $this->isDebugModeEnabled() || $this->request->getServerProtocol() === 'https';
 	}
@@ -105,8 +103,7 @@ class LoginController extends BaseOidcController
 	 * @param bool|null $throttle
 	 * @return TemplateResponse
 	 */
-	private function buildProtocolErrorResponse(?bool $throttle = null): TemplateResponse
-	{
+	private function buildProtocolErrorResponse(?bool $throttle = null): TemplateResponse {
 		$params = [
 			'errors' => [
 				['error' => $this->l10n->t('You must access Nextcloud with HTTPS to use OpenID Connect.')],
@@ -120,8 +117,7 @@ class LoginController extends BaseOidcController
 	 * @param string|null $redirectUrl
 	 * @return RedirectResponse
 	 */
-	private function getRedirectResponse(?string $redirectUrl = null): RedirectResponse
-	{
+	private function getRedirectResponse(?string $redirectUrl = null): RedirectResponse {
 		return new RedirectResponse(
 			$redirectUrl === null
 			? $this->urlGenerator->getBaseUrl()
@@ -139,8 +135,7 @@ class LoginController extends BaseOidcController
 	 * @param string|null $redirectUrl
 	 * @return DataDisplayResponse|RedirectResponse|TemplateResponse
 	 */
-	public function login(int $providerId, ?string $redirectUrl = null)
-	{
+	public function login(int $providerId, ?string $redirectUrl = null) {
 		if ($this->userSession->isLoggedIn()) {
 			return $this->getRedirectResponse($redirectUrl);
 		}
@@ -151,7 +146,7 @@ class LoginController extends BaseOidcController
 
 		try {
 			$provider = $this->providerMapper->getProvider($providerId);
-		} catch (DoesNotExistException | MultipleObjectsReturnedException $e) {
+		} catch (DoesNotExistException|MultipleObjectsReturnedException $e) {
 			$message = $this->l10n->t('There is no such OpenID Connect provider.');
 			return $this->buildErrorTemplateResponse($message, Http::STATUS_NOT_FOUND, ['provider_not_found' => $providerId]);
 		}
@@ -315,8 +310,7 @@ class LoginController extends BaseOidcController
 	 * @throws SessionNotAvailableException
 	 * @throws \JsonException
 	 */
-	public function code(string $state = '', string $code = '', string $scope = '', string $error = '', string $error_description = '')
-	{
+	public function code(string $state = '', string $code = '', string $scope = '', string $error = '', string $error_description = '') {
 		if (!$this->isSecure()) {
 			return $this->buildProtocolErrorResponse();
 		}
@@ -351,7 +345,7 @@ class LoginController extends BaseOidcController
 			return $this->build403TemplateResponse($message, Http::STATUS_FORBIDDEN, ['reason' => 'state does not match'], true);
 		}
 
-		$providerId = (int) $this->session->get(self::PROVIDERID);
+		$providerId = (int)$this->session->get(self::PROVIDERID);
 		$provider = $this->providerMapper->getProvider($providerId);
 		try {
 			$providerClientSecret = $this->crypto->decrypt($provider->getClientSecret());
@@ -407,9 +401,9 @@ class LoginController extends BaseOidcController
 				$requestBody,
 				$headers
 			);
-		} catch (ClientException | ServerException $e) {
+		} catch (ClientException|ServerException $e) {
 			$response = $e->getResponse();
-			$body = (string) $response->getBody();
+			$body = (string)$response->getBody();
 			$responseBodyArray = json_decode($body, true);
 			if ($responseBodyArray !== null && isset($responseBodyArray['error'], $responseBodyArray['error_description'])) {
 				$this->logger->debug('Failed to contact the OIDC provider token endpoint', [
@@ -647,8 +641,7 @@ class LoginController extends BaseOidcController
 	 * @throws SessionNotAvailableException
 	 * @throws \JsonException
 	 */
-	public function singleLogoutService()
-	{
+	public function singleLogoutService() {
 		// TODO throttle in all failing cases
 		$oidcSystemConfig = $this->config->getSystemValue('user_oidc', []);
 		$targetUrl = $this->urlGenerator->getAbsoluteURL('/');
@@ -661,7 +654,7 @@ class LoginController extends BaseOidcController
 
 				try {
 					$key = $this->config->getSystemValueString('gss.jwt.key', '');
-					$decoded = (array) JWT::decode($jwt, new Key($key, 'HS256'));
+					$decoded = (array)JWT::decode($jwt, new Key($key, 'HS256'));
 
 					$providerId = $decoded['oidcProviderId'] ?? null;
 				} catch (\Exception $e) {
@@ -672,8 +665,8 @@ class LoginController extends BaseOidcController
 			}
 			if ($providerId) {
 				try {
-					$provider = $this->providerMapper->getProvider((int) $providerId);
-				} catch (DoesNotExistException | MultipleObjectsReturnedException $e) {
+					$provider = $this->providerMapper->getProvider((int)$providerId);
+				} catch (DoesNotExistException|MultipleObjectsReturnedException $e) {
 					$message = $this->l10n->t('There is no such OpenID Connect provider.');
 					return $this->buildErrorTemplateResponse($message, Http::STATUS_NOT_FOUND, ['provider_id' => $providerId]);
 				}
@@ -726,8 +719,7 @@ class LoginController extends BaseOidcController
 	 * @throws Exception
 	 * @throws \JsonException
 	 */
-	public function backChannelLogout(string $providerIdentifier, string $logout_token = ''): JSONResponse
-	{
+	public function backChannelLogout(string $providerIdentifier, string $logout_token = ''): JSONResponse {
 		// get the provider
 		$provider = $this->providerService->getProviderByIdentifier($providerIdentifier);
 		if ($provider === null) {
@@ -810,7 +802,7 @@ class LoginController extends BaseOidcController
 		}
 
 		// i don't know why but the cast is necessary
-		$authTokenId = (int) $oidcSession->getAuthtokenId();
+		$authTokenId = (int)$oidcSession->getAuthtokenId();
 		try {
 			$authToken = $this->authTokenProvider->getTokenById($authTokenId);
 			// we could also get the auth token by nc session ID
@@ -855,8 +847,7 @@ class LoginController extends BaseOidcController
 		);
 	}
 
-	private function toCodeChallenge(string $data): string
-	{
+	private function toCodeChallenge(string $data): string {
 		// Basically one big work around for the base64url decode being weird
 		$h = pack('H*', hash('sha256', $data));
 		$s = base64_encode($h); // Regular base64 encoder

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -120,8 +120,8 @@ class LoginController extends BaseOidcController {
 	private function getRedirectResponse(?string $redirectUrl = null): RedirectResponse {
 		return new RedirectResponse(
 			$redirectUrl === null
-			? $this->urlGenerator->getBaseUrl()
-			: preg_replace('/^https?:\/\/[^\/]+/', '', $redirectUrl)
+				? $this->urlGenerator->getBaseUrl()
+				: preg_replace('/^https?:\/\/[^\/]+/', '', $redirectUrl)
 		);
 	}
 
@@ -377,10 +377,10 @@ class LoginController extends BaseOidcController {
 			$tokenEndpointAuthMethod = 'client_secret_post';
 			// Use Basic only if client_secret_post is not available as supported by the endpoint
 			if (
-				array_key_exists('token_endpoint_auth_methods_supported', $discovery) &&
-				is_array($discovery['token_endpoint_auth_methods_supported']) &&
-				in_array('client_secret_basic', $discovery['token_endpoint_auth_methods_supported']) &&
-				!in_array('client_secret_post', $discovery['token_endpoint_auth_methods_supported'])
+				array_key_exists('token_endpoint_auth_methods_supported', $discovery)
+				&& is_array($discovery['token_endpoint_auth_methods_supported'])
+				&& in_array('client_secret_basic', $discovery['token_endpoint_auth_methods_supported'])
+				&& !in_array('client_secret_post', $discovery['token_endpoint_auth_methods_supported'])
 			) {
 				$tokenEndpointAuthMethod = 'client_secret_basic';
 			}

--- a/lib/Helper/HttpClientHelper.php
+++ b/lib/Helper/HttpClientHelper.php
@@ -14,8 +14,7 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 use Id4me\RP\HttpClient;
 use OCP\Http\Client\IClientService;
 
-class HttpClientHelper implements HttpClient
-{
+class HttpClientHelper implements HttpClient {
 
 	public function __construct(
 		private IClientService $clientService,
@@ -23,8 +22,7 @@ class HttpClientHelper implements HttpClient
 	) {
 	}
 
-	public function get($url, array $options = [])
-	{
+	public function get($url, array $options = []) {
 		$client = $this->clientService->newClient();
 
 		if ($this->config->getSystemValue('httpclient.allowselfsigned', false)) {
@@ -34,8 +32,7 @@ class HttpClientHelper implements HttpClient
 		return $client->get($url, $options)->getBody();
 	}
 
-	public function post($url, $body, array $headers = [])
-	{
+	public function post($url, $body, array $headers = []) {
 		$client = $this->clientService->newClient();
 
 		$options = [

--- a/lib/Helper/HttpClientHelper.php
+++ b/lib/Helper/HttpClientHelper.php
@@ -22,7 +22,7 @@ class HttpClientHelper implements HttpClient {
 	) {
 	}
 
-	public function get($url, array $options = []) {
+	public function get($url, array $headers = [], array $options = []) {
 		$client = $this->clientService->newClient();
 
 		if ($this->config->getSystemValue('httpclient.allowselfsigned', false)) {

--- a/lib/Helper/HttpClientHelper.php
+++ b/lib/Helper/HttpClientHelper.php
@@ -8,32 +8,55 @@ declare(strict_types=1);
 
 namespace OCA\UserOIDC\Helper;
 
-use OCP\Http\Client\IClientService;
+use OCP\IConfig;
 
 require_once __DIR__ . '/../../vendor/autoload.php';
 use Id4me\RP\HttpClient;
+use OCP\Http\Client\IClientService;
 
-class HttpClientHelper implements HttpClient {
+class HttpClientHelper implements HttpClient
+{
 
 	public function __construct(
 		private IClientService $clientService,
+		private IConfig $config,
 	) {
 	}
 
-	public function get($url, array $headers = []) {
+	public function get($url, array $options = [])
+	{
 		$client = $this->clientService->newClient();
 
-		return $client->get($url, [
-			'headers' => $headers,
-		])->getBody();
+		if ($this->config->getSystemValue('httpclient.allowselfsigned', false)) {
+			$options = array_merge(
+				$options,
+				[
+					'verify' => false
+				]
+			);
+		}
+
+		return $client->get($url, $options)->getBody();
 	}
 
-	public function post($url, $body, array $headers = []) {
+	public function post($url, $body, array $headers = [])
+	{
 		$client = $this->clientService->newClient();
 
-		return $client->post($url, [
+		$options = [
 			'headers' => $headers,
 			'body' => $body,
-		])->getBody();
+		];
+
+		if ($this->config->getSystemValue('httpclient.allowselfsigned', false)) {
+			$options = array_merge(
+				$options,
+				[
+					'verify' => false
+				]
+			);
+		}
+
+		return $client->post($url, $options)->getBody();
 	}
 }

--- a/lib/Helper/HttpClientHelper.php
+++ b/lib/Helper/HttpClientHelper.php
@@ -23,9 +23,12 @@ class HttpClientHelper implements HttpClient {
 	}
 
 	public function get($url, array $headers = [], array $options = []) {
+		$oidcConfig = $this->config->getSystemValue('user_oidc', []);
+
 		$client = $this->clientService->newClient();
 
-		if ($this->config->getSystemValue('httpclient.allowselfsigned', false)) {
+		if (isset($oidcConfig['httpclient.allowselfsigned'])
+			&& !in_array($oidcConfig['httpclient.allowselfsigned'], [false, 'false', 0, '0'], true)) {
 			$options['verify'] = false;
 		}
 
@@ -33,6 +36,7 @@ class HttpClientHelper implements HttpClient {
 	}
 
 	public function post($url, $body, array $headers = []) {
+		$oidcConfig = $this->config->getSystemValue('user_oidc', []);
 		$client = $this->clientService->newClient();
 
 		$options = [
@@ -40,7 +44,8 @@ class HttpClientHelper implements HttpClient {
 			'body' => $body,
 		];
 
-		if ($this->config->getSystemValue('httpclient.allowselfsigned', false)) {
+		if (isset($oidcConfig['httpclient.allowselfsigned'])
+			&& !in_array($oidcConfig['httpclient.allowselfsigned'], [false, 'false', 0, '0'], true)) {
 			$options['verify'] = false;
 		}
 

--- a/lib/Helper/HttpClientHelper.php
+++ b/lib/Helper/HttpClientHelper.php
@@ -28,12 +28,7 @@ class HttpClientHelper implements HttpClient
 		$client = $this->clientService->newClient();
 
 		if ($this->config->getSystemValue('httpclient.allowselfsigned', false)) {
-			$options = array_merge(
-				$options,
-				[
-					'verify' => false
-				]
-			);
+			$options['verify'] = false;
 		}
 
 		return $client->get($url, $options)->getBody();
@@ -49,12 +44,7 @@ class HttpClientHelper implements HttpClient
 		];
 
 		if ($this->config->getSystemValue('httpclient.allowselfsigned', false)) {
-			$options = array_merge(
-				$options,
-				[
-					'verify' => false
-				]
-			);
+			$options['verify'] = false;
 		}
 
 		return $client->post($url, $options)->getBody();

--- a/lib/Service/DiscoveryService.php
+++ b/lib/Service/DiscoveryService.php
@@ -96,8 +96,8 @@ class DiscoveryService {
 	public function buildAuthorizationUrl(string $authorizationEndpoint, array $extraGetParameters = []): string {
 		$parsedUrl = parse_url($authorizationEndpoint);
 
-		$urlWithoutParams =
-			(isset($parsedUrl['scheme']) ? $parsedUrl['scheme'] . '://' : '')
+		$urlWithoutParams
+			= (isset($parsedUrl['scheme']) ? $parsedUrl['scheme'] . '://' : '')
 			. ($parsedUrl['host'] ?? '')
 			. (isset($parsedUrl['port']) ? ':' . strval($parsedUrl['port']) : '')
 			. ($parsedUrl['path'] ?? '');

--- a/lib/Service/DiscoveryService.php
+++ b/lib/Service/DiscoveryService.php
@@ -9,16 +9,15 @@ declare(strict_types=1);
 
 namespace OCA\UserOIDC\Service;
 
-use OCP\ICache;
-use OCP\ICacheFactory;
-use Psr\Log\LoggerInterface;
-use OCA\UserOIDC\Db\Provider; 
+use OCA\UserOIDC\Db\Provider;
 use OCA\UserOIDC\Helper\HttpClientHelper;
 use OCA\UserOIDC\Vendor\Firebase\JWT\JWK;
 use OCA\UserOIDC\Vendor\Firebase\JWT\JWT;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use Psr\Log\LoggerInterface;
 
-class DiscoveryService
-{
+class DiscoveryService {
 	public const INVALIDATE_DISCOVERY_CACHE_AFTER_SECONDS = 3600;
 	public const INVALIDATE_JWKS_CACHE_AFTER_SECONDS = 3600;
 
@@ -47,8 +46,7 @@ class DiscoveryService
 		$this->cache = $cacheFactory->createDistributed('user_oidc');
 	}
 
-	public function obtainDiscovery(Provider $provider): array
-	{
+	public function obtainDiscovery(Provider $provider): array {
 		$cacheKey = 'discovery-' . $provider->getDiscoveryEndpoint();
 		$cachedDiscovery = $this->cache->get($cacheKey);
 		if ($cachedDiscovery === null) {
@@ -70,10 +68,9 @@ class DiscoveryService
 	 * @return array
 	 * @throws \JsonException
 	 */
-	public function obtainJWK(Provider $provider, string $tokenToDecode, bool $useCache = true): array
-	{
+	public function obtainJWK(Provider $provider, string $tokenToDecode, bool $useCache = true): array {
 		$lastJwksRefresh = $this->providerService->getSetting($provider->getId(), ProviderService::SETTING_JWKS_CACHE_TIMESTAMP);
-		if ($lastJwksRefresh !== '' && $useCache && (int) $lastJwksRefresh > time() - self::INVALIDATE_JWKS_CACHE_AFTER_SECONDS) {
+		if ($lastJwksRefresh !== '' && $useCache && (int)$lastJwksRefresh > time() - self::INVALIDATE_JWKS_CACHE_AFTER_SECONDS) {
 			$rawJwks = $this->providerService->getSetting($provider->getId(), ProviderService::SETTING_JWKS_CACHE);
 			$rawJwks = json_decode($rawJwks, true);
 		} else {
@@ -96,8 +93,7 @@ class DiscoveryService
 	 * @param array $extraGetParameters
 	 * @return string
 	 */
-	public function buildAuthorizationUrl(string $authorizationEndpoint, array $extraGetParameters = []): string
-	{
+	public function buildAuthorizationUrl(string $authorizationEndpoint, array $extraGetParameters = []): string {
 		$parsedUrl = parse_url($authorizationEndpoint);
 
 		$urlWithoutParams =
@@ -126,8 +122,7 @@ class DiscoveryService
 	 * @return array
 	 * @throws \Exception
 	 */
-	private function fixJwksAlg(array $jwks, string $jwt): array
-	{
+	private function fixJwksAlg(array $jwks, string $jwt): array {
 		$jwtParts = explode('.', $jwt);
 		$jwtHeader = json_decode(JWT::urlsafeB64Decode($jwtParts[0]), true);
 		if (!isset($jwtHeader['kid'])) {

--- a/lib/Service/DiscoveryService.php
+++ b/lib/Service/DiscoveryService.php
@@ -9,15 +9,16 @@ declare(strict_types=1);
 
 namespace OCA\UserOIDC\Service;
 
-use OCA\UserOIDC\Db\Provider;
-use OCA\UserOIDC\Vendor\Firebase\JWT\JWK;
-use OCA\UserOIDC\Vendor\Firebase\JWT\JWT;
-use OCP\Http\Client\IClientService;
 use OCP\ICache;
 use OCP\ICacheFactory;
 use Psr\Log\LoggerInterface;
+use OCA\UserOIDC\Db\Provider; 
+use OCA\UserOIDC\Helper\HttpClientHelper;
+use OCA\UserOIDC\Vendor\Firebase\JWT\JWK;
+use OCA\UserOIDC\Vendor\Firebase\JWT\JWT;
 
-class DiscoveryService {
+class DiscoveryService
+{
 	public const INVALIDATE_DISCOVERY_CACHE_AFTER_SECONDS = 3600;
 	public const INVALIDATE_JWKS_CACHE_AFTER_SECONDS = 3600;
 
@@ -39,23 +40,22 @@ class DiscoveryService {
 
 	public function __construct(
 		private LoggerInterface $logger,
-		private IClientService $clientService,
+		private HttpClientHelper $clientService,
 		private ProviderService $providerService,
 		ICacheFactory $cacheFactory,
 	) {
 		$this->cache = $cacheFactory->createDistributed('user_oidc');
 	}
 
-	public function obtainDiscovery(Provider $provider): array {
+	public function obtainDiscovery(Provider $provider): array
+	{
 		$cacheKey = 'discovery-' . $provider->getDiscoveryEndpoint();
 		$cachedDiscovery = $this->cache->get($cacheKey);
 		if ($cachedDiscovery === null) {
 			$url = $provider->getDiscoveryEndpoint();
 			$this->logger->debug('Obtaining discovery endpoint: ' . $url);
 
-			$client = $this->clientService->newClient();
-			$response = $client->get($url);
-			$cachedDiscovery = $response->getBody();
+			$cachedDiscovery = $this->clientService->get($url);
 
 			$this->cache->set($cacheKey, $cachedDiscovery, self::INVALIDATE_DISCOVERY_CACHE_AFTER_SECONDS);
 		}
@@ -70,15 +70,15 @@ class DiscoveryService {
 	 * @return array
 	 * @throws \JsonException
 	 */
-	public function obtainJWK(Provider $provider, string $tokenToDecode, bool $useCache = true): array {
+	public function obtainJWK(Provider $provider, string $tokenToDecode, bool $useCache = true): array
+	{
 		$lastJwksRefresh = $this->providerService->getSetting($provider->getId(), ProviderService::SETTING_JWKS_CACHE_TIMESTAMP);
-		if ($lastJwksRefresh !== '' && $useCache && (int)$lastJwksRefresh > time() - self::INVALIDATE_JWKS_CACHE_AFTER_SECONDS) {
+		if ($lastJwksRefresh !== '' && $useCache && (int) $lastJwksRefresh > time() - self::INVALIDATE_JWKS_CACHE_AFTER_SECONDS) {
 			$rawJwks = $this->providerService->getSetting($provider->getId(), ProviderService::SETTING_JWKS_CACHE);
 			$rawJwks = json_decode($rawJwks, true);
 		} else {
 			$discovery = $this->obtainDiscovery($provider);
-			$client = $this->clientService->newClient();
-			$responseBody = $client->get($discovery['jwks_uri'])->getBody();
+			$responseBody = $this->clientService->get($discovery['jwks_uri']);
 			$rawJwks = json_decode($responseBody, true);
 			// cache jwks
 			$this->providerService->setSetting($provider->getId(), ProviderService::SETTING_JWKS_CACHE, $responseBody);
@@ -96,7 +96,8 @@ class DiscoveryService {
 	 * @param array $extraGetParameters
 	 * @return string
 	 */
-	public function buildAuthorizationUrl(string $authorizationEndpoint, array $extraGetParameters = []): string {
+	public function buildAuthorizationUrl(string $authorizationEndpoint, array $extraGetParameters = []): string
+	{
 		$parsedUrl = parse_url($authorizationEndpoint);
 
 		$urlWithoutParams =
@@ -125,7 +126,8 @@ class DiscoveryService {
 	 * @return array
 	 * @throws \Exception
 	 */
-	private function fixJwksAlg(array $jwks, string $jwt): array {
+	private function fixJwksAlg(array $jwks, string $jwt): array
+	{
 		$jwtParts = explode('.', $jwt);
 		$jwtHeader = json_decode(JWT::urlsafeB64Decode($jwtParts[0]), true);
 		if (!isset($jwtHeader['kid'])) {

--- a/lib/Service/OIDCService.php
+++ b/lib/Service/OIDCService.php
@@ -9,14 +9,13 @@ declare(strict_types=1);
 
 namespace OCA\UserOIDC\Service;
 
-use Throwable;
-use OCP\Security\ICrypto;
-use Psr\Log\LoggerInterface;
 use OCA\UserOIDC\Db\Provider;
 use OCA\UserOIDC\Helper\HttpClientHelper;
+use OCP\Security\ICrypto;
+use Psr\Log\LoggerInterface;
+use Throwable;
 
-class OIDCService
-{
+class OIDCService {
 
 	public function __construct(
 		private DiscoveryService $discoveryService,
@@ -26,8 +25,7 @@ class OIDCService
 	) {
 	}
 
-	public function userinfo(Provider $provider, string $accessToken): array
-	{
+	public function userinfo(Provider $provider, string $accessToken): array {
 		$url = $this->discoveryService->obtainDiscovery($provider)['userinfo_endpoint'] ?? null;
 		if ($url === null) {
 			return [];
@@ -46,8 +44,7 @@ class OIDCService
 		}
 	}
 
-	public function introspection(Provider $provider, string $accessToken): array
-	{
+	public function introspection(Provider $provider, string $accessToken): array {
 		try {
 			$providerClientSecret = $this->crypto->decrypt($provider->getClientSecret());
 		} catch (\Exception $e) {

--- a/lib/Service/OIDCService.php
+++ b/lib/Service/OIDCService.php
@@ -38,7 +38,7 @@ class OIDCService {
 			],
 		];
 		try {
-			return json_decode($this->clientService->get($url, $options), true);
+			return json_decode($this->clientService->get($url, [], $options), true);
 		} catch (Throwable $e) {
 			return [];
 		}

--- a/lib/Service/TokenService.php
+++ b/lib/Service/TokenService.php
@@ -35,8 +35,7 @@ use Psr\Log\LoggerInterface;
  * This is helpful to debug:
  * tail -f data/nextcloud.log | grep "\[Token" | jq ".time,.message"
  */
-class TokenService
-{
+class TokenService {
 
 	private const SESSION_TOKEN_KEY = Application::APP_ID . '-user-token';
 
@@ -59,8 +58,7 @@ class TokenService
 
 	}
 
-	public function storeToken(array $tokenData): Token
-	{
+	public function storeToken(array $tokenData): Token {
 		$token = new Token($tokenData);
 		$this->session->set(self::SESSION_TOKEN_KEY, json_encode($token, JSON_THROW_ON_ERROR));
 		$this->logger->debug('[TokenService] Store token');
@@ -75,8 +73,7 @@ class TokenService
 	 * @return Token|null Return a token only if it is valid or has been successfully refreshed
 	 * @throws \JsonException
 	 */
-	public function getToken(bool $refreshIfExpired = true): ?Token
-	{
+	public function getToken(bool $refreshIfExpired = true): ?Token {
 		$sessionData = $this->session->get(self::SESSION_TOKEN_KEY);
 		if (!$sessionData) {
 			$this->logger->debug('[TokenService] getToken: no session data');
@@ -108,8 +105,7 @@ class TokenService
 	 * @throws \JsonException
 	 * @throws PreConditionNotMetException
 	 */
-	public function checkLoginToken(): void
-	{
+	public function checkLoginToken(): void {
 		$storeLoginTokenEnabled = $this->config->getAppValue(Application::APP_ID, 'store_login_token', '0') === '1';
 		if (!$storeLoginTokenEnabled) {
 			return;
@@ -140,8 +136,7 @@ class TokenService
 		}
 	}
 
-	public function reauthenticate(int $providerId)
-	{
+	public function reauthenticate(int $providerId) {
 		// Logout the user and redirect to the oidc login flow to gather a fresh token
 		$this->userSession->logout();
 		$redirectUrl = $this->urlGenerator->linkToRouteAbsolute(Application::APP_ID . '.login.login', [
@@ -160,8 +155,7 @@ class TokenService
 	 * @throws DoesNotExistException
 	 * @throws MultipleObjectsReturnedException
 	 */
-	public function refresh(Token $token): Token
-	{
+	public function refresh(Token $token): Token {
 		$oidcProvider = $this->providerMapper->getProvider($token->getProviderId());
 		$discovery = $this->discoveryService->obtainDiscovery($oidcProvider);
 
@@ -206,8 +200,7 @@ class TokenService
 		}
 	}
 
-	public function decodeIdToken(Token $token): array
-	{
+	public function decodeIdToken(Token $token): array {
 		$provider = $this->providerMapper->getProvider($token->getProviderId());
 		$jwks = $this->discoveryService->obtainJWK($provider, $token->getIdToken());
 		JWT::$leeway = 60;
@@ -225,8 +218,7 @@ class TokenService
 	 * @throws TokenExchangeFailedException
 	 * @throws \JsonException
 	 */
-	public function getExchangedToken(string $targetAudience, array $extraScopes = []): Token
-	{
+	public function getExchangedToken(string $targetAudience, array $extraScopes = []): Token {
 		$storeLoginTokenEnabled = $this->config->getAppValue(Application::APP_ID, 'store_login_token', '0') === '1';
 		if (!$storeLoginTokenEnabled) {
 			throw new TokenExchangeFailedException(
@@ -297,9 +289,9 @@ class TokenService
 				['provider_id' => $loginToken->getProviderId()],
 			);
 			return new Token($tokenData);
-		} catch (ClientException | ServerException $e) {
+		} catch (ClientException|ServerException $e) {
 			$response = $e->getResponse();
-			$body = (string) $response->getBody();
+			$body = (string)$response->getBody();
 			$this->logger->error('[TokenService] Failed to exchange token, client/server error in the exchange request', ['response_body' => $body, 'exception' => $e]);
 
 			$parsedBody = json_decode(trim($body), true);
@@ -318,7 +310,7 @@ class TokenService
 					$e,
 				);
 			}
-		} catch (\Exception | \Throwable $e) {
+		} catch (\Exception|\Throwable $e) {
 			$this->logger->error('[TokenService] Failed to exchange token ', ['exception' => $e]);
 			throw new TokenExchangeFailedException('Failed to exchange token, error in the exchange request', 0, $e);
 		}
@@ -331,8 +323,7 @@ class TokenService
 	 * @param string $targetAudience
 	 * @return Token|null
 	 */
-	public function getTokenFromOidcProviderApp(string $userId, string $targetAudience, array $extraScopes = [], string $resource = ''): ?Token
-	{
+	public function getTokenFromOidcProviderApp(string $userId, string $targetAudience, array $extraScopes = [], string $resource = ''): ?Token {
 		if (!class_exists(\OCA\OIDCIdentityProvider\AppInfo\Application::class)) {
 			$this->logger->warning('[TokenService] Failed to get token from Oidc provider app, oidc app is not installed');
 			return null;
@@ -354,7 +345,7 @@ class TokenService
 				$this->logger->debug('[TokenService] The Oidc provider app did not generate any access/id token');
 				return null;
 			}
-		} catch (\Exception | \Throwable $e) {
+		} catch (\Exception|\Throwable $e) {
 			$this->logger->debug('[TokenService] The Oidc provider app failed to generate a token');
 			return null;
 		}

--- a/tests/unit/Service/DiscoveryServiceTest.php
+++ b/tests/unit/Service/DiscoveryServiceTest.php
@@ -8,9 +8,9 @@
 declare(strict_types=1);
 
 
+use OCA\UserOIDC\Helper\HttpClientHelper;
 use OCA\UserOIDC\Service\DiscoveryService;
 use OCA\UserOIDC\Service\ProviderService;
-use OCP\Http\Client\IClientService;
 use OCP\ICacheFactory;
 use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -24,9 +24,9 @@ class DiscoveryServiceTest extends TestCase {
 	 */
 	private $logger;
 	/**
-	 * @var IClientService|MockObject
+	 * @var HttpClientHelper|MockObject
 	 */
-	private $clientService;
+	private $clientHelper;
 	/**
 	 * @var ProviderService|MockObject
 	 */
@@ -43,10 +43,10 @@ class DiscoveryServiceTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 		$this->logger = $this->createMock(LoggerInterface::class);
-		$this->clientService = $this->createMock(IClientService::class);
+		$this->clientHelper = $this->createMock(HttpClientHelper::class);
 		$this->providerService = $this->createMock(ProviderService::class);
 		$this->cacheFactory = $this->createMock(ICacheFactory::class);
-		$this->discoveryService = new DiscoveryService($this->logger, $this->clientService, $this->providerService, $this->cacheFactory);
+		$this->discoveryService = new DiscoveryService($this->logger, $this->clientHelper, $this->providerService, $this->cacheFactory);
 	}
 
 	public function testBuildAuthorizationUrl() {


### PR DESCRIPTION
## Pull Request: Add support for self-signed certificates and custom OIDC prompt
### Summary

This PR introduces two key improvements to enhance development and integration flexibility with custom OAuth2/OIDC providers:
 - Features Added
    - Self-signed certificate support:   A new system config flag httpclient.allowselfsigned enables accepting self-signed SSL certificates during development or internal deployments.    When enabled, SSL verification is disabled (verify => false) in HTTP client requests.

- Custom OIDC prompt support:
   - Adds support for the standard OIDC prompt values: none, login, and consent.
        Introduces a custom internal prompt designed specifically for private applications using [OAuth2 Passport Server](https://github.com/elyerr/oauth2-passport-server).

        Documentation for this prompt is available here: [Prompts Supported](https://gitlab.com/elyerr/oauth2-passport-server/-/wikis/home/prompts-supported)

##  Note
Use of self-signed certificates is intended only for development or trusted internal networks. It should be disabled in production environments to ensure secure communication.