### PR TITLE
Use custom error/403 template

### DIFF
--- a/lib/Controller/Id4meController.php
+++ b/lib/Controller/Id4meController.php
@@ -66,7 +66,7 @@ class Id4meController extends BaseOidcController {
 		private LoggerInterface $logger,
 		private ICrypto $crypto,
 	) {
-		parent::__construct($request, $config);
+		parent::__construct($request, $config, $l10n);
 
 		$this->id4me = new Service($clientHelper);
 	}

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -88,7 +88,7 @@ class LoginController extends BaseOidcController {
 		private TokenService $tokenService,
 		private OidcService $oidcService,
 	) {
-		parent::__construct($request, $config);
+		parent::__construct($request, $config, $l10n);
 	}
 
 	/**
@@ -105,12 +105,10 @@ class LoginController extends BaseOidcController {
 	 */
 	private function buildProtocolErrorResponse(?bool $throttle = null): TemplateResponse {
 		$params = [
-			'errors' => [
-				['error' => $this->l10n->t('You must access Nextcloud with HTTPS to use OpenID Connect.')],
-			],
+			'message' => $this->l10n->t('You must access Nextcloud with HTTPS to use OpenID Connect.'),
 		];
 		$throttleMetadata = ['reason' => 'insecure connection'];
-		return $this->buildFailureTemplateResponse('', 'error', $params, Http::STATUS_NOT_FOUND, $throttleMetadata, $throttle);
+		return $this->buildFailureTemplateResponse($params, Http::STATUS_NOT_FOUND, $throttleMetadata, $throttle);
 	}
 
 	/**

--- a/templates/error.php
+++ b/templates/error.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+?>
+<div class="guest-box">
+    <h2><?php p($_['title']); ?></h2>
+    <ul>
+        <li>
+            <p><?php p($_['message']); ?></p>
+        </li>
+    </ul>
+    <br>
+    <p>
+        <a class="button primary" href="<?php p(\OCP\Server::get(\OCP\IURLGenerator::class)->linkTo('', 'index.php')) ?>">
+            <?php p($l->t('Back to %s', [$theme->getName()])); ?>
+        </a>
+    </p>
+</div>


### PR DESCRIPTION
We need a template that includes a 'back to nextcloud' button.
The core:403 one has it starting at NC 32. We need it now and for the error template as well. So I went with a custom template in user_oidc that looks like the core ones.

### Before

<img width="771" height="501" alt="image" src="https://github.com/user-attachments/assets/498890d6-a8ab-4c70-86a7-27e5e0cdc655" />


### After

<img width="696" height="477" alt="image" src="https://github.com/user-attachments/assets/0f080a8b-6378-43c5-92b4-38d0c1c444b6" />
