### PR TITLE
Fix/store login token

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -591,7 +591,7 @@ class LoginController extends BaseOidcController {
 			$this->eventDispatcher->dispatchTyped(new UserLoggedInEvent($user, $user->getUID(), null, false));
 		}
 
-		$storeLoginTokenEnabled = $this->config->getAppValue(Application::APP_ID, 'store_login_token', '0') === '1';
+		$storeLoginTokenEnabled = in_array($oidcSystemConfig['store_login_token'], ['1', 1, true]);
 		if ($storeLoginTokenEnabled) {
 			// store all token information for potential token exchange requests
 			$tokenData = array_merge(

--- a/lib/Listener/ExternalTokenRequestedListener.php
+++ b/lib/Listener/ExternalTokenRequestedListener.php
@@ -23,12 +23,19 @@ use Psr\Log\LoggerInterface;
  */
 class ExternalTokenRequestedListener implements IEventListener {
 
+	/**
+	 * User oidc config
+	 * @var 
+	 */
+	private $oidcSystemConfig;
+
 	public function __construct(
 		private IUserSession $userSession,
 		private TokenService $tokenService,
 		private IConfig $config,
 		private LoggerInterface $logger,
 	) {
+		$this->oidcSystemConfig = $this->config->getSystemValue('user_oidc', []);
 	}
 
 	public function handle(Event $event): void {
@@ -42,7 +49,7 @@ class ExternalTokenRequestedListener implements IEventListener {
 
 		$this->logger->debug('[ExternalTokenRequestedListener] received request');
 
-		$storeLoginTokenEnabled = $this->config->getAppValue(Application::APP_ID, 'store_login_token', '0') === '1';
+		$storeLoginTokenEnabled = in_array($this->oidcSystemConfig['store_login_token'], ['1', 1, true]);
 		if (!$storeLoginTokenEnabled) {
 			throw new GetExternalTokenFailedException('Failed to get external token, login token is not stored', 0);
 		}

--- a/lib/Service/TokenService.php
+++ b/lib/Service/TokenService.php
@@ -41,6 +41,12 @@ class TokenService {
 
 	private IClient $client;
 
+	/**
+	 * user_oidc config
+	 * @var 
+	 */
+	private $oidcSystemConfig;
+
 	public function __construct(
 		public HttpClientHelper $clientService,
 		private ISession $session,
@@ -55,7 +61,7 @@ class TokenService {
 		private DiscoveryService $discoveryService,
 		private ProviderMapper $providerMapper,
 	) {
-
+		$this->oidcSystemConfig = $this->config->getSystemValue('user_oidc', []);
 	}
 
 	public function storeToken(array $tokenData): Token {
@@ -107,7 +113,7 @@ class TokenService {
 	 * @throws PreConditionNotMetException
 	 */
 	public function checkLoginToken(): void {
-		$storeLoginTokenEnabled = $this->config->getAppValue(Application::APP_ID, 'store_login_token', '0') === '1';
+		$storeLoginTokenEnabled = in_array($this->oidcSystemConfig['store_login_token'], ['1', 1, true]);
 		if (!$storeLoginTokenEnabled) {
 			return;
 		}
@@ -220,7 +226,7 @@ class TokenService {
 	 * @throws \JsonException
 	 */
 	public function getExchangedToken(string $targetAudience, array $extraScopes = []): Token {
-		$storeLoginTokenEnabled = $this->config->getAppValue(Application::APP_ID, 'store_login_token', '0') === '1';
+		$storeLoginTokenEnabled = in_array($this->oidcSystemConfig['store_login_token'], ['1', 1, true]);
 		if (!$storeLoginTokenEnabled) {
 			throw new TokenExchangeFailedException(
 				'Failed to exchange token, storing the login token is disabled. It can be enabled in config.php',

--- a/lib/Settings/AdminSettings.php
+++ b/lib/Settings/AdminSettings.php
@@ -21,6 +21,7 @@ use OCP\Util;
 
 class AdminSettings implements ISettings {
 
+	private $oidcSystemConfig;
 	public function __construct(
 		private ProviderService $providerService,
 		private ID4MeService $Id4MeService,
@@ -28,6 +29,7 @@ class AdminSettings implements ISettings {
 		private IConfig $config,
 		private IInitialState $initialStateService,
 	) {
+		$this->oidcSystemConfig = $this->config->getSystemValue('user_oidc', []);
 	}
 
 	public function getForm() {
@@ -37,7 +39,7 @@ class AdminSettings implements ISettings {
 		);
 		$this->initialStateService->provideInitialState(
 			'storeLoginTokenState',
-			$this->config->getAppValue(Application::APP_ID, 'store_login_token', '0') === '1'
+			in_array($this->oidcSystemConfig['store_login_token'], ['1', 1, true])
 		);
 		$this->initialStateService->provideInitialState(
 			'providers',


### PR DESCRIPTION
Pull Request: Fix OIDC Session Token Storage

This PR fixes an issue where the store_login_token method was not properly storing authentication data in the session. As a result, essential information returned by the authorization server—such as id_token, access_token, and other claims—was not available for later use.

By correcting this behavior, the session now correctly retains the OIDC token data, which can be reliably used for validation, user identification, or other post-login processes that depend on the authorization server's response.