### PR TITLE
Change the behaviour related with the 'prompt' authentication param

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -272,7 +272,7 @@ class LoginController extends BaseOidcController {
 			'nonce' => $nonce,
 		];
 
-		if ($oidcConfig['prompt']) {
+		if (isset($oidcConfig['prompt']) && is_string($oidcConfig['prompt'])) {
 			$data['prompt'] = $oidcConfig['prompt'];
 		}
 

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -270,9 +270,11 @@ class LoginController extends BaseOidcController {
 			'claims' => json_encode($claims),
 			'state' => $state,
 			'nonce' => $nonce,
-			'prompt' => $oidcConfig['prompt'] ?? 'consent'
 		];
 
+		if ($oidcConfig['prompt']) {
+			$data['prompt'] = $oidcConfig['prompt'];
+		}
 
 		if ($isPkceEnabled) {
 			$data['code_challenge'] = $this->toCodeChallenge($code_verifier);

--- a/lib/Service/TokenService.php
+++ b/lib/Service/TokenService.php
@@ -269,9 +269,10 @@ class TokenService {
 				'audience' => $targetAudience,
 				'scope' => $scope,
 			];
-			if ($this->config->getSystemValue('user_oidc.prompt') !== '') {
+			$oidcConfig = $this->config->getSystemValue('user_oidc', []);
+			if (isset($oidcConfig['prompt']) && is_string($oidcConfig['prompt'])) {
 				// none, consent, login and internal for oauth2 passport server
-				$tokenEndpointParams['prompt'] = $this->config->getSystemValue('user_oidc.prompt');
+				$tokenEndpointParams['prompt'] = $oidcConfig['prompt'];
 			}
 			// more in https://www.keycloak.org/securing-apps/token-exchange
 			$body = $this->clientService->post(

--- a/lib/Service/TokenService.php
+++ b/lib/Service/TokenService.php
@@ -255,24 +255,28 @@ class TokenService {
 				}
 			}
 			$this->logger->debug('[TokenService] Exchanging the token: ' . $discovery['token_endpoint']);
+			$tokenEndpointParams = [
+				'client_id' => $oidcProvider->getClientId(),
+				'client_secret' => $clientSecret,
+				'grant_type' => 'urn:ietf:params:oauth:grant-type:token-exchange',
+				'subject_token' => $loginToken->getAccessToken(),
+				'subject_token_type' => 'urn:ietf:params:oauth:token-type:access_token',
+				// can also be
+				// urn:ietf:params:oauth:token-type:access_token
+				// or urn:ietf:params:oauth:token-type:id_token
+				// this one will get us an access token and refresh token within the response
+				'requested_token_type' => 'urn:ietf:params:oauth:token-type:refresh_token',
+				'audience' => $targetAudience,
+				'scope' => $scope,
+			];
+			if ($this->config->getSystemValue('user_oidc.prompt') !== '') {
+				// none, consent, login and internal for oauth2 passport server
+				$tokenEndpointParams['prompt'] = $this->config->getSystemValue('user_oidc.prompt');
+			}
 			// more in https://www.keycloak.org/securing-apps/token-exchange
 			$body = $this->clientService->post(
 				$discovery['token_endpoint'],
-				[
-					'client_id' => $oidcProvider->getClientId(),
-					'client_secret' => $clientSecret,
-					'grant_type' => 'urn:ietf:params:oauth:grant-type:token-exchange',
-					'subject_token' => $loginToken->getAccessToken(),
-					'subject_token_type' => 'urn:ietf:params:oauth:token-type:access_token',
-					// can also be
-					// urn:ietf:params:oauth:token-type:access_token
-					// or urn:ietf:params:oauth:token-type:id_token
-					// this one will get us an access token and refresh token within the response
-					'requested_token_type' => 'urn:ietf:params:oauth:token-type:refresh_token',
-					'audience' => $targetAudience,
-					'scope' => $scope,
-					'prompt' => $this->config->getSystemValue('user_oidc.prompt', 'consent') // none,consent,login and internal for oauth2 passport server
-				]
+				$tokenEndpointParams,
 			);
 			$this->logger->debug('[TokenService] Token exchange request params', [
 				'client_id' => $oidcProvider->getClientId(),


### PR DESCRIPTION
Only use the 'prompt' param for the authorization and token endpoints if it's defined in NC config, drop 'consent' as the default used value.

closes #1173 #1163