### PR TITLE
Handle session token revocation

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 	<name>OpenID Connect user backend</name>
 	<summary>Use an OpenID Connect backend to login to your Nextcloud</summary>
 	<description>Allows flexible configuration of an OIDC server as Nextcloud login user backend.</description>
-	<version>7.3.2</version>
+	<version>7.4.0</version>
 	<licence>agpl</licence>
 	<author>Roeland Jago Douma</author>
 	<author>Julius Härtl</author>

--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -19,6 +19,7 @@ use OCA\UserOIDC\Listener\ExchangedTokenRequestedListener;
 use OCA\UserOIDC\Listener\ExternalTokenRequestedListener;
 use OCA\UserOIDC\Listener\InternalTokenRequestedListener;
 use OCA\UserOIDC\Listener\TimezoneHandlingListener;
+use OCA\UserOIDC\Listener\TokenInvalidatedListener;
 use OCA\UserOIDC\Service\ID4MeService;
 use OCA\UserOIDC\Service\SettingsService;
 use OCA\UserOIDC\Service\TokenService;
@@ -59,6 +60,10 @@ class Application extends App implements IBootstrap {
 		$context->registerEventListener(ExchangedTokenRequestedEvent::class, ExchangedTokenRequestedListener::class);
 		$context->registerEventListener(ExternalTokenRequestedEvent::class, ExternalTokenRequestedListener::class);
 		$context->registerEventListener(InternalTokenRequestedEvent::class, InternalTokenRequestedListener::class);
+
+		if (class_exists(\OCP\Authentication\Events\TokenInvalidatedEvent::class)) {
+			$context->registerEventListener(\OCP\Authentication\Events\TokenInvalidatedEvent::class, TokenInvalidatedListener::class);
+		}
 	}
 
 	public function boot(IBootContext $context): void {

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -610,7 +610,7 @@ class LoginController extends BaseOidcController {
 		// for backchannel logout
 		try {
 			$authToken = $this->authTokenProvider->getToken($this->session->getId());
-			$this->sessionMapper->createSession(
+			$this->sessionMapper->createOrUpdateSession(
 				$idTokenPayload->sid ?? 'fallback-sid',
 				$idTokenPayload->sub ?? 'fallback-sub',
 				$idTokenPayload->iss ?? 'fallback-iss',

--- a/lib/Db/Provider.php
+++ b/lib/Db/Provider.php
@@ -11,17 +11,17 @@ namespace OCA\UserOIDC\Db;
 use OCP\AppFramework\Db\Entity;
 
 /**
- * @method string getIdentifier()
- * @method void setIdentifier(string $identifier)
- * @method string getClientId()
- * @method void setClientId(string $clientId)
- * @method string getClientSecret()
- * @method void setClientSecret(string $clientSecret)
- * @method string getDiscoveryEndpoint()
- * @method void setDiscoveryEndpoint(string $discoveryEndpoint)
- * @method string getEndSessionEndpoint()
- * @method void setEndSessionEndpoint(string $endSessionEndpoint)
- * @method void setScope(string $scope)
+ * @method \string getIdentifier()
+ * @method \void setIdentifier(string $identifier)
+ * @method \string getClientId()
+ * @method \void setClientId(string $clientId)
+ * @method \string getClientSecret()
+ * @method \void setClientSecret(string $clientSecret)
+ * @method \string|\null getDiscoveryEndpoint()
+ * @method \void setDiscoveryEndpoint(?string $discoveryEndpoint)
+ * @method \string|\null getEndSessionEndpoint()
+ * @method \void setEndSessionEndpoint(?string $endSessionEndpoint)
+ * @method \void setScope(string $scope)
  */
 class Provider extends Entity implements \JsonSerializable {
 
@@ -34,10 +34,10 @@ class Provider extends Entity implements \JsonSerializable {
 	/** @var string */
 	protected $clientSecret;
 
-	/** @var string */
+	/** @var ?string */
 	protected $discoveryEndpoint;
 
-	/** @var string */
+	/** @var ?string */
 	protected $endSessionEndpoint;
 
 	/** @var string */

--- a/lib/Db/Session.php
+++ b/lib/Db/Session.php
@@ -11,38 +11,49 @@ namespace OCA\UserOIDC\Db;
 use OCP\AppFramework\Db\Entity;
 
 /**
- * @method string getSid()
- * @method void setSid(string $sid)
- * @method string getSub()
- * @method void setSub(string $sub)
- * @method string getIss()
- * @method void setIss(string $iss)
- * @method int getAuthtokenId()
- * @method void setAuthtokenId(int $authtokenId)
- * @method string getNcSessionId()
- * @method void setNcSessionId(string $ncSessionId)
- * @method int getCreatedAt()
- * @method void setCreatedAt(int $createdAt)
+ * @method \string getSid()
+ * @method \void setSid(string $sid)
+ * @method \string getSub()
+ * @method \void setSub(string $sub)
+ * @method \string getIss()
+ * @method \void setIss(string $iss)
+ * @method \int getAuthtokenId()
+ * @method \void setAuthtokenId(int $authtokenId)
+ * @method \string getNcSessionId()
+ * @method \void setNcSessionId(string $ncSessionId)
+ * @method \int getCreatedAt()
+ * @method \void setCreatedAt(int $createdAt)
+ * @method \string|\null getIdToken()
+ * @method \void setIdToken(?string $idToken)
+ * @method \string|\null getUserId()
+ * @method \void setUserId(?string $userId)
+ * @method \int getProviderId()
+ * @method \void setProviderId(int $providerId)
+ * @method \int getIdpSessionClosed()
+ * @method \void setIdpSessionClosed(int $idpSessionClosed)
  */
 class Session extends Entity implements \JsonSerializable {
 
 	/** @var string */
 	protected $sid;
-
 	/** @var string */
 	protected $sub;
-
 	/** @var string */
 	protected $iss;
-
 	/** @var int */
 	protected $authtokenId;
-
 	/** @var string */
 	protected $ncSessionId;
-
 	/** @var int */
 	protected $createdAt;
+	/** @var ?string */
+	protected $idToken;
+	/** @var ?string */
+	protected $userId;
+	/** @var int */
+	protected $providerId;
+	/** @var int */
+	protected $idpSessionClosed;
 
 	public function __construct() {
 		$this->addType('sid', 'string');
@@ -51,18 +62,25 @@ class Session extends Entity implements \JsonSerializable {
 		$this->addType('authtoken_id', 'integer');
 		$this->addType('nc_session_id', 'string');
 		$this->addType('created_at', 'integer');
+		$this->addType('id_token', 'string');
+		$this->addType('user_id', 'string');
+		$this->addType('provider_id', 'integer');
+		$this->addType('idp_session_closed', 'integer');
 	}
 
 	#[\ReturnTypeWillChange]
 	public function jsonSerialize() {
 		return [
-			'id' => $this->id,
-			'sid' => $this->sid,
-			'sub' => $this->sub,
-			'iss' => $this->iss,
-			'authtoken_id' => $this->authtokenId,
-			'nc_session_id' => $this->ncSessionId,
-			'created_at' => $this->createdAt,
+			'id' => $this->getId(),
+			'sid' => $this->getSid(),
+			'sub' => $this->getSub(),
+			'iss' => $this->getIss(),
+			'authtoken_id' => $this->getAuthtokenId(),
+			'nc_session_id' => $this->getNcSessionId(),
+			'created_at' => $this->getCreatedAt(),
+			'user_id' => $this->getUserId(),
+			'provider_id' => $this->getProviderId(),
+			'idp_session_closed' => $this->getIdpSessionClosed() !== 0,
 		];
 	}
 }

--- a/lib/Db/SessionMapper.php
+++ b/lib/Db/SessionMapper.php
@@ -16,12 +16,16 @@ use OCP\DB\Exception;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 
 use OCP\IDBConnection;
+use OCP\Security\ICrypto;
 
 /**
  * @extends QBMapper<Session>
  */
 class SessionMapper extends QBMapper {
-	public function __construct(IDBConnection $db) {
+	public function __construct(
+		IDBConnection $db,
+		private ICrypto $crypto,
+	) {
 		parent::__construct($db, 'user_oidc_sessions', Session::class);
 	}
 
@@ -189,7 +193,7 @@ class SessionMapper extends QBMapper {
 		$session->setAuthtokenId($authtokenId);
 		$session->setNcSessionId($ncSessionid);
 		$session->setCreatedAt($createdAt);
-		$session->setIdToken($idToken);
+		$session->setIdToken($this->crypto->encrypt($idToken));
 		$session->setUserId($userId);
 		$session->setProviderId($providerId);
 		$session->setIdpSessionClosed($idpSessionClosed ? 1 : 0);

--- a/lib/Helper/HttpClientHelper.php
+++ b/lib/Helper/HttpClientHelper.php
@@ -27,8 +27,10 @@ class HttpClientHelper implements HttpClient {
 
 		$client = $this->clientService->newClient();
 
-		if (isset($oidcConfig['httpclient.allowselfsigned'])
-			&& !in_array($oidcConfig['httpclient.allowselfsigned'], [false, 'false', 0, '0'], true)) {
+		$debugModeEnabled = $this->config->getSystemValueBool('debug', false);
+		if ($debugModeEnabled
+			|| (isset($oidcConfig['httpclient.allowselfsigned'])
+				&& !in_array($oidcConfig['httpclient.allowselfsigned'], [false, 'false', 0, '0'], true))) {
 			$options['verify'] = false;
 		}
 

--- a/lib/Listener/TokenInvalidatedListener.php
+++ b/lib/Listener/TokenInvalidatedListener.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\UserOIDC\Listener;
+
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ServerException;
+use OCA\UserOIDC\Db\ProviderMapper;
+use OCA\UserOIDC\Db\SessionMapper;
+use OCA\UserOIDC\Helper\HttpClientHelper;
+use OCA\UserOIDC\Service\DiscoveryService;
+use OCP\AppFramework\Db\DoesNotExistException;
+use OCP\AppFramework\Db\MultipleObjectsReturnedException;
+use OCP\Authentication\Events\TokenInvalidatedEvent;
+use OCP\DB\Exception;
+use OCP\EventDispatcher\Event;
+use OCP\EventDispatcher\IEventListener;
+use OCP\IURLGenerator;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @implements IEventListener<TokenInvalidatedEvent|Event>
+ */
+class TokenInvalidatedListener implements IEventListener {
+
+	public function __construct(
+		private LoggerInterface $logger,
+		private SessionMapper $sessionMapper,
+		private ProviderMapper $providerMapper,
+		private DiscoveryService $discoveryService,
+		private IURLGenerator $urlGenerator,
+		private HttpClientHelper $httpClientHelper,
+	) {
+	}
+
+	public function handle(Event $event): void {
+		if (!$event instanceof TokenInvalidatedEvent) {
+			return;
+		}
+
+		$this->logger->debug('[TokenInvalidatedListener] received event', [
+			'token_id' => $event->getTokenId(),
+			'user_id' => $event->getUserId(),
+		]);
+
+		try {
+			$oidcSession = $this->sessionMapper->getSessionByAuthTokenAndUid($event->getTokenId(), $event->getUserId());
+		} catch (Exception|DoesNotExistException|MultipleObjectsReturnedException $e) {
+			$this->logger->warning('[TokenInvalidatedListener] Could not find the OIDC session related with an invalidated token', [
+				'token_id' => $event->getTokenId(),
+				'user_id' => $event->getUserId(),
+				'exception' => $e,
+			]);
+			return;
+		}
+		// we have nothing to do if we know the idp session is already closed
+		if ($oidcSession->getIdpSessionClosed() !== 0) {
+			$this->logger->warning('[TokenInvalidatedListener] The session is already closed on the IdP side', [
+				'token_id' => $event->getTokenId(),
+				'user_id' => $event->getUserId(),
+			]);
+			return;
+		}
+
+		// now we call the end_session_endpoint
+		try {
+			$provider = $this->providerMapper->getProvider($oidcSession->getProviderId());
+		} catch (DoesNotExistException|MultipleObjectsReturnedException $e) {
+			$this->logger->warning('[TokenInvalidatedListener] Could not find the OIDC provider of a session related with an invalidated token', [
+				'token_id' => $event->getTokenId(),
+				'user_id' => $event->getUserId(),
+				'provider_id' => $oidcSession->getProviderId(),
+				'exception' => $e,
+			]);
+			return;
+		}
+
+		// Check if a custom end_session_endpoint is set in the provider otherwise use the default one provided by the openid-configuration
+		$discoveryData = $this->discoveryService->obtainDiscovery($provider);
+		$defaultEndSessionEndpoint = $discoveryData['end_session_endpoint'] ?? null;
+		$customEndSessionEndpoint = $provider->getEndSessionEndpoint();
+		$endSessionEndpoint = $customEndSessionEndpoint ?: $defaultEndSessionEndpoint;
+
+		if ($endSessionEndpoint === null || $endSessionEndpoint === '') {
+			$this->logger->warning('[TokenInvalidatedListener] Could not find the end_session_endpoint of the OIDC provider of a session related with an invalidated token', [
+				'token_id' => $event->getTokenId(),
+				'user_id' => $event->getUserId(),
+				'provider_id' => $oidcSession->getProviderId(),
+			]);
+			return;
+		}
+
+		$endSessionEndpoint .= '?post_logout_redirect_uri=' . $this->urlGenerator->getAbsoluteURL('/');
+		$endSessionEndpoint .= '&client_id=' . $provider->getClientId();
+		$endSessionEndpoint .= '&id_token_hint=' . $oidcSession->getIdToken();
+
+		$this->logger->warning('[TokenInvalidatedListener] requesting ' . $endSessionEndpoint);
+		try {
+			$this->httpClientHelper->get($endSessionEndpoint);
+		} catch (ClientException|ServerException $e) {
+			$response = $e->getResponse();
+			$body = (string)$response->getBody();
+			$this->logger->debug('[TokenInvalidatedListener] Failed to request the end_session_endpoint, client or server error', [
+				'status_code' => $response->getStatusCode(),
+				'body' => $body,
+				'exception' => $e,
+			]);
+		} catch (\Exception $e) {
+			$this->logger->debug('[TokenInvalidatedListener] Failed to request the end_session_endpoint', ['exception' => $e]);
+		}
+	}
+}

--- a/lib/Listener/TokenInvalidatedListener.php
+++ b/lib/Listener/TokenInvalidatedListener.php
@@ -100,7 +100,7 @@ class TokenInvalidatedListener implements IEventListener {
 
 		$this->logger->warning('[TokenInvalidatedListener] requesting ' . $endSessionEndpoint);
 		try {
-			$this->httpClientHelper->get($endSessionEndpoint);
+			$this->httpClientHelper->get($endSessionEndpoint, [], ['timeout' => 5]);
 		} catch (ClientException|ServerException $e) {
 			$response = $e->getResponse();
 			$body = (string)$response->getBody();
@@ -112,5 +112,7 @@ class TokenInvalidatedListener implements IEventListener {
 		} catch (\Exception $e) {
 			$this->logger->debug('[TokenInvalidatedListener] Failed to request the end_session_endpoint', ['exception' => $e]);
 		}
+		// we know this oidc session is not useful anymore, we can delete it
+		$this->sessionMapper->delete($oidcSession);
 	}
 }

--- a/lib/Migration/Version070400Date20250820141709.php
+++ b/lib/Migration/Version070400Date20250820141709.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\UserOIDC\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+class Version070400Date20250820141709 extends SimpleMigrationStep {
+	/**
+	 * @param IOutput $output
+	 * @param Closure $schemaClosure
+	 * @param array $options
+	 * @return null|ISchemaWrapper
+	 */
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+
+		$schemaChanged = false;
+
+		if ($schema->hasTable('user_oidc_sessions')) {
+			$table = $schema->getTable('user_oidc_sessions');
+			if (!$table->hasColumn('id_token')) {
+				$table->addColumn('id_token', Types::TEXT, [
+					'notnull' => false,
+				]);
+				$schemaChanged = true;
+			}
+			if (!$table->hasColumn('user_id')) {
+				$table->addColumn('user_id', Types::STRING, [
+					'notnull' => false,
+					'length' => 64,
+					'default' => null,
+				]);
+				$schemaChanged = true;
+			}
+			if (!$table->hasColumn('provider_id')) {
+				$table->addColumn('provider_id', Types::BIGINT, [
+					'notnull' => true,
+					'default' => 0,
+					'unsigned' => true,
+				]);
+				$schemaChanged = true;
+			}
+			if (!$table->hasColumn('idp_session_closed')) {
+				$table->addColumn('idp_session_closed', Types::SMALLINT, [
+					'notnull' => true,
+					'default' => 0,
+					'unsigned' => true,
+				]);
+				$schemaChanged = true;
+			}
+		}
+
+		return $schemaChanged ? $schema : null;
+	}
+}

--- a/psalm.xml
+++ b/psalm.xml
@@ -74,5 +74,6 @@
 		<file name="tests/stubs/oca_files_events.php" />
 		<file name="tests/stubs/oca_oidc_events.php" />
 		<file name="tests/stubs/ocp_imapperexception.php" />
+		<file name="tests/stubs/ocp_token_invalidated_event.php" />
 	</stubs>
 </psalm>

--- a/tests/stubs/ocp_token_invalidated_event.php
+++ b/tests/stubs/ocp_token_invalidated_event.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCP\Authentication\Events {
+	interface TokenInvalidatedEvent extends \OCP\EventDispatcher\Event {
+		public function getUserId(): string;
+		public function getTokenId(): int;
+	}
+}

--- a/tests/stubs/ocp_token_invalidated_event.php
+++ b/tests/stubs/ocp_token_invalidated_event.php
@@ -7,7 +7,6 @@
 
 namespace OCP\Authentication\Events {
 	interface TokenInvalidatedEvent extends \OCP\EventDispatcher\Event {
-		public function getUserId(): string;
-		public function getTokenId(): int;
+		public function getToken(): \OCP\Authentication\Token\IToken;
 	}
 }


### PR DESCRIPTION
:warning: This depends on https://github.com/nextcloud/server/pull/54545 which will be included in Nextcloud 32.

When a user logs in twice (with user_oidc) and invalidates the other session in the security settings, for example, it does not kill the IdP session so, in the browser session that is revoked, it is possible to complete the login flow without authenticating again in the IdP.

This PR adds a listener on a new event dispatched when an auth token is invalidated: `OCP\Authentication\Events\TokenInvalidatedEvent`
If we have an Oidc session that matches this invalidated token, we call the end_session_endpoint to make sure the related IdP session is terminated.

We also cleanup the session entry (in a user_oidc table) when this happens.

New columns in the `oc_user_oidc_session` table:
* `user_id` is used with `authtoken_id` to get the session when a token is invalidated
* `provider_id` is necessary to get the `client_id` so we can send it as a param to the end_session_endpoint
* `id_token` is the login ID token, we also need it as a param to the end_session_endpoint
* `idp_session_closed` helps with backchannel logout (explained below)

To make sure we don't mess with the backchannel logout, there is a new `idp_session_closed` column in the `oc_user_oidc_session` table. When we receive a backchannel logout request, we know that the IdP is currently killing one of its sessions. We call `authTokenProvider->invalidateTokenById` to kill the related Nextcloud session. So we will receive the `OCP\Authentication\Events\TokenInvalidatedEvent` but this time we don't need to make a request to the end_session_endpoint, we know the IdP session is already terminated. So we store that information in the session in the `idp_session_closed` column so the listener can ignore the event related with this Oidc session.

closes #1159
closes https://github.com/nextcloud/server/issues/53942