### PR TITLE
Use client_secret_basic by default, use client_secret_post if supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,22 @@ for private or internal applications without requiring user consent or interacti
 Documentation for all supported prompt values is available here:
 [Oauth2 passport server prompts-supported](https://gitlab.com/elyerr/oauth2-passport-server/-/wikis/home/prompts-supported)
 
+## `user_oidc.default_token_endpoint_auth_method`
+
+The OIDC specifications are clear on this. It is stated in https://openid.net/specs/openid-connect-discovery-1_0.html
+that if `token_endpoint_auth_methods_supported` is not set in the provider discovery endpoint payload,
+`client_secret_basic` should be used as default authentication method.
+
+But it has been reported that, with Authelia for example, only `client_secret_post` might be allowed while `token_endpoint_auth_methods_supported`
+is not set in the discovery. In such case, you can set the default token endpoint authentication method with:
+
+```php
+'user_oidc' => [
+  'default_token_endpoint_auth_method' => 'client_secret_post'
+]
+```
+
+
 ---
 
 ### User IDs

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -385,18 +385,19 @@ class LoginController extends BaseOidcController {
 			}
 
 			$headers = [];
-			$tokenEndpointAuthMethod = 'client_secret_post';
-			// Use Basic only if client_secret_post is not available as supported by the endpoint
+			$tokenEndpointAuthMethod = 'client_secret_basic';
+			// follow what is described in https://openid.net/specs/openid-connect-discovery-1_0.html
+			// about token_endpoint_auth_methods_supported: "If omitted, the default is client_secret_basic"
+			// Use client_secret_post if supported
 			if (
 				array_key_exists('token_endpoint_auth_methods_supported', $discovery)
 				&& is_array($discovery['token_endpoint_auth_methods_supported'])
-				&& in_array('client_secret_basic', $discovery['token_endpoint_auth_methods_supported'])
-				&& !in_array('client_secret_post', $discovery['token_endpoint_auth_methods_supported'])
+				&& in_array('client_secret_post', $discovery['token_endpoint_auth_methods_supported'], true)
 			) {
-				$tokenEndpointAuthMethod = 'client_secret_basic';
+				$tokenEndpointAuthMethod = 'client_secret_post';
 			}
 
-			if ($tokenEndpointAuthMethod == 'client_secret_basic') {
+			if ($tokenEndpointAuthMethod === 'client_secret_basic') {
 				$headers = [
 					'Authorization' => 'Basic ' . base64_encode($provider->getClientId() . ':' . $providerClientSecret),
 					'Content-Type' => 'application/x-www-form-urlencoded',

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -385,10 +385,15 @@ class LoginController extends BaseOidcController {
 			}
 
 			$headers = [];
-			$tokenEndpointAuthMethod = 'client_secret_basic';
 			// follow what is described in https://openid.net/specs/openid-connect-discovery-1_0.html
 			// about token_endpoint_auth_methods_supported: "If omitted, the default is client_secret_basic"
 			// Use client_secret_post if supported
+			// We still allow changing the default auth method in config.php
+			$tokenEndpointAuthMethod = $oidcSystemConfig['default_token_endpoint_auth_method'] ?? 'client_secret_basic';
+			// deal with invalid values
+			if (!in_array($tokenEndpointAuthMethod, ['client_secret_basic', 'client_secret_post'], true)) {
+				$tokenEndpointAuthMethod = 'client_secret_basic';
+			}
 			if (
 				array_key_exists('token_endpoint_auth_methods_supported', $discovery)
 				&& is_array($discovery['token_endpoint_auth_methods_supported'])


### PR DESCRIPTION
closes #1198

As stated in https://openid.net/specs/openid-connect-discovery-1_0.html about `token_endpoint_auth_methods_supported`:

> If omitted, the default is client_secret_basic

The new behaviour is:
* If  `token_endpoint_auth_methods_supported` is not set in the discovery payload: use `client_secret_basic`
* If `token_endpoint_auth_methods_supported` is set and contains `client_secret_post`, use it

:warning: It is now also possible to set the default auth method (when `token_endpoint_auth_methods_supported` is not set) in config.php with:

```php
'user_oidc' => [
  'default_token_endpoint_auth_method' => 'client_secret_post',
]
```

@hendrik1120 Be aware that you will need to change this default because in your case,  `token_endpoint_auth_methods_supported` is not set and `client_secret_post` is the only supported method. You can set that value in config.php now (before this change is released), it will be effective with the next release.
