### PR TITLE
docs: Give explicit type for allow_multiple_user_backends app config

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ login. Admins can still use the regular login through adding the `?direct=1`
 parameter to the login URL.
 
 ```bash
-sudo -u www-data php var/www/nextcloud/occ config:app:set --value=0 user_oidc allow_multiple_user_backends
+sudo -u www-data php var/www/nextcloud/occ config:app:set --type=string --value=0 user_oidc allow_multiple_user_backends
 ```
 
 ### PKCE


### PR DESCRIPTION
The app was broken for me with
```
{"reqId":"DihuHRmsPwO0aumqJxz2","level":2,"time":"2025-10-10T17:53:13+00:00","remoteAddr":"2a02:8071:67f1:12e0:54ea:e5e5:e86c:c644","user":"--","app":"user_oidc","method":"GET","url":"/login","message":"conflict with value type from database","userAgent":"Mozilla/5.0 (X11; Linux x86_64; rv:143.0) Gecko/20100101 Firefox/143.0","version":"31.0.9.1","data":{"app":"user_oidc","key":"allow_multiple_user_backends","type":"4","knownType":"8"}}
```
which I believe is a regression from https://github.com/nextcloud/user_oidc/pull/1200/commits/d440778a8c8209c86e96905321be7450cd333b7b

My previous command was `occ config:app:set user_oidc allow_multiple_user_backends --type integer --value 0` because I assumed the type would be an integer.
The readme should therefore mention explicitly that it's a string, as it's currently only implicit, but still required.

Depending on the number of instances that break with this change, you might want to consider changing the type to be an integer, as it currently only seems to be used with 0 or 1 as the value.