### PR TITLE
Prevent crash in some user backend methods

### DIFF
--- a/lib/Db/Id4MeMapper.php
+++ b/lib/Db/Id4MeMapper.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace OCA\UserOIDC\Db;
 
 use OCP\AppFramework\Db\QBMapper;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
 /**
@@ -31,7 +32,7 @@ class Id4MeMapper extends QBMapper {
 		$qb->select('*')
 			->from($this->getTableName())
 			->where(
-				$qb->expr()->eq('identifier', $qb->createNamedParameter($identifier))
+				$qb->expr()->eq('identifier', $qb->createNamedParameter($identifier, IQueryBuilder::PARAM_STR))
 			);
 
 		return $this->findEntity($qb);

--- a/lib/Db/ProviderMapper.php
+++ b/lib/Db/ProviderMapper.php
@@ -14,6 +14,7 @@ use OCP\AppFramework\Db\MultipleObjectsReturnedException;
 use OCP\AppFramework\Db\QBMapper;
 use OCP\DB\Exception;
 
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
 
 /**
@@ -36,7 +37,7 @@ class ProviderMapper extends QBMapper {
 		$qb->select('*')
 			->from($this->getTableName())
 			->where(
-				$qb->expr()->eq('id', $qb->createNamedParameter($id))
+				$qb->expr()->eq('id', $qb->createNamedParameter($id, IQueryBuilder::PARAM_INT))
 			);
 
 		return $this->findEntity($qb);
@@ -56,7 +57,7 @@ class ProviderMapper extends QBMapper {
 		$qb->select('*')
 			->from($this->getTableName())
 			->where(
-				$qb->expr()->eq('identifier', $qb->createNamedParameter($identifier))
+				$qb->expr()->eq('identifier', $qb->createNamedParameter($identifier, IQueryBuilder::PARAM_STR))
 			);
 
 		return $this->findEntity($qb);

--- a/lib/Db/UserMapper.php
+++ b/lib/Db/UserMapper.php
@@ -12,6 +12,7 @@ use OCA\UserOIDC\Service\LocalIdService;
 use OCP\AppFramework\Db\IMapperException;
 use OCP\AppFramework\Db\QBMapper;
 use OCP\Cache\CappedMemoryCache;
+use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IConfig;
 use OCP\IDBConnection;
 
@@ -47,7 +48,7 @@ class UserMapper extends QBMapper {
 		$qb->select('*')
 			->from($this->getTableName())
 			->where(
-				$qb->expr()->eq('user_id', $qb->createNamedParameter($uid))
+				$qb->expr()->eq('user_id', $qb->createNamedParameter($uid, IQueryBuilder::PARAM_STR))
 			);
 
 		/** @var User $user */
@@ -56,7 +57,7 @@ class UserMapper extends QBMapper {
 		return $user;
 	}
 
-	public function find(string $search, $limit = null, $offset = null): array {
+	public function find(string $search, ?int $limit = null, ?int $offset = null): array {
 		$qb = $this->db->getQueryBuilder();
 
 		$oidcSystemConfig = $this->config->getSystemValue('user_oidc', []);
@@ -72,23 +73,31 @@ class UserMapper extends QBMapper {
 				->where($qb->expr()->iLike('user_id', $qb->createPositionalParameter('%' . $this->db->escapeLikeParameter($search) . '%')))
 				->orWhere($qb->expr()->iLike('display_name', $qb->createPositionalParameter('%' . $this->db->escapeLikeParameter($search) . '%')))
 				->orWhere($qb->expr()->iLike('configvalue', $qb->createPositionalParameter('%' . $this->db->escapeLikeParameter($search) . '%')))
-				->orderBy($qb->func()->lower('user_id'), 'ASC')
-				->setMaxResults($limit)
-				->setFirstResult($offset);
+				->orderBy($qb->func()->lower('user_id'), 'ASC');
+			if ($limit !== null) {
+				$qb->setMaxResults($limit);
+			}
+			if ($offset !== null) {
+				$qb->setFirstResult($offset);
+			}
 		} else {
 			$qb->select('user_id', 'display_name')
 				->from($this->getTableName())
 				->where($qb->expr()->iLike('user_id', $qb->createPositionalParameter('%' . $this->db->escapeLikeParameter($search) . '%')))
 				->orWhere($qb->expr()->iLike('display_name', $qb->createPositionalParameter('%' . $this->db->escapeLikeParameter($search) . '%')))
-				->orderBy($qb->func()->lower('user_id'), 'ASC')
-				->setMaxResults($limit)
-				->setFirstResult($offset);
+				->orderBy($qb->func()->lower('user_id'), 'ASC');
+			if ($limit !== null) {
+				$qb->setMaxResults($limit);
+			}
+			if ($offset !== null) {
+				$qb->setFirstResult($offset);
+			}
 		}
 
 		return $this->findEntities($qb);
 	}
 
-	public function findDisplayNames(string $search, $limit = null, $offset = null): array {
+	public function findDisplayNames(string $search, ?int $limit = null, ?int $offset = null): array {
 		$qb = $this->db->getQueryBuilder();
 
 		$oidcSystemConfig = $this->config->getSystemValue('user_oidc', []);
@@ -104,17 +113,25 @@ class UserMapper extends QBMapper {
 				->where($qb->expr()->iLike('user_id', $qb->createPositionalParameter('%' . $this->db->escapeLikeParameter($search) . '%')))
 				->orWhere($qb->expr()->iLike('display_name', $qb->createPositionalParameter('%' . $this->db->escapeLikeParameter($search) . '%')))
 				->orWhere($qb->expr()->iLike('configvalue', $qb->createPositionalParameter('%' . $this->db->escapeLikeParameter($search) . '%')))
-				->orderBy($qb->func()->lower('user_id'), 'ASC')
-				->setMaxResults($limit)
-				->setFirstResult($offset);
+				->orderBy($qb->func()->lower('user_id'), 'ASC');
+			if ($limit !== null) {
+				$qb->setMaxResults($limit);
+			}
+			if ($offset !== null) {
+				$qb->setFirstResult($offset);
+			}
 		} else {
 			$qb->select('user_id', 'display_name')
 				->from($this->getTableName())
 				->where($qb->expr()->iLike('user_id', $qb->createPositionalParameter('%' . $this->db->escapeLikeParameter($search) . '%')))
 				->orWhere($qb->expr()->iLike('display_name', $qb->createPositionalParameter('%' . $this->db->escapeLikeParameter($search) . '%')))
-				->orderBy($qb->func()->lower('user_id'), 'ASC')
-				->setMaxResults($limit)
-				->setFirstResult($offset);
+				->orderBy($qb->func()->lower('user_id'), 'ASC');
+			if ($limit !== null) {
+				$qb->setMaxResults($limit);
+			}
+			if ($offset !== null) {
+				$qb->setFirstResult($offset);
+			}
 		}
 
 		$result = $qb->executeQuery();

--- a/lib/User/Backend.php
+++ b/lib/User/Backend.php
@@ -83,17 +83,29 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 		}
 	}
 
-	public function getUsers($search = '', $limit = null, $offset = null) {
+	public function getUsers($search = '', $limit = null, $offset = null): array {
+		if (!is_string($search)
+			|| ($limit !== null && !is_int($limit))
+			|| ($offset !== null && !is_int($offset))
+		) {
+			return [];
+		}
 		return array_map(function ($user) {
 			return $user->getUserId();
 		}, $this->userMapper->find($search, $limit, $offset));
 	}
 
 	public function userExists($uid): bool {
+		if (!is_string($uid)) {
+			return false;
+		}
 		return $this->userMapper->userExists($uid);
 	}
 
 	public function getDisplayName($uid): string {
+		if (!is_string($uid)) {
+			return (string)$uid;
+		}
 		try {
 			$user = $this->userMapper->getUser($uid);
 		} catch (DoesNotExistException $e) {
@@ -104,6 +116,12 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 	}
 
 	public function getDisplayNames($search = '', $limit = null, $offset = null): array {
+		if (!is_string($search)
+			|| ($limit !== null && !is_int($limit))
+			|| ($offset !== null && !is_int($offset))
+		) {
+			return [];
+		}
 		return $this->userMapper->findDisplayNames($search, $limit, $offset);
 	}
 


### PR DESCRIPTION
Those methods are inherited from bad interfaces.
We now prevent a crash when provided params have the wrong type. This is not supposed to happen but it did according to #1238.
Also make some UserMapper methods stricter and cleaner and add a few missing query param types.

closes #1238