### PR TITLE
Reduce log level of non-critical messages in TokenInvalidatedListener

### DIFF
--- a/lib/Listener/TokenInvalidatedListener.php
+++ b/lib/Listener/TokenInvalidatedListener.php
@@ -56,7 +56,7 @@ class TokenInvalidatedListener implements IEventListener {
 		try {
 			$oidcSession = $this->sessionMapper->getSessionByAuthTokenAndUid($eventTokenId, $eventTokenUserId);
 		} catch (Exception|DoesNotExistException|MultipleObjectsReturnedException $e) {
-			$this->logger->warning('[TokenInvalidatedListener] Could not find the OIDC session related with an invalidated token', [
+			$this->logger->debug('[TokenInvalidatedListener] Could not find the OIDC session related with an invalidated token', [
 				'token_id' => $eventTokenId,
 				'user_id' => $eventTokenUserId,
 				'exception' => $e,
@@ -65,7 +65,7 @@ class TokenInvalidatedListener implements IEventListener {
 		}
 		// we have nothing to do if we know the idp session is already closed
 		if ($oidcSession->getIdpSessionClosed() !== 0) {
-			$this->logger->warning('[TokenInvalidatedListener] The session is already closed on the IdP side', [
+			$this->logger->debug('[TokenInvalidatedListener] The session is already closed on the IdP side', [
 				'token_id' => $eventTokenId,
 				'user_id' => $eventTokenUserId,
 			]);
@@ -110,7 +110,7 @@ class TokenInvalidatedListener implements IEventListener {
 		$endSessionEndpoint .= '&client_id=' . $provider->getClientId();
 		$endSessionEndpoint .= '&id_token_hint=' . $decryptedIdToken;
 
-		$this->logger->warning('[TokenInvalidatedListener] requesting ' . $endSessionEndpoint);
+		$this->logger->debug('[TokenInvalidatedListener] requesting ' . $endSessionEndpoint);
 		try {
 			$this->httpClientHelper->get($endSessionEndpoint, [], ['timeout' => 5]);
 		} catch (ClientException|ServerException $e) {


### PR DESCRIPTION
This is especially aiming to remove the first warning log (`Could not find the OIDC session related with an invalidated token`) that is produced quite often because the "single logout" (when a user logs out manually in the UI) deletes the OIDC session before invalidating the authentication token so we never find the OIDC session in this case, it's already gone.