### PR TITLE
Add UI warning explaining the consequence of disabling unique user IDs

### DIFF
--- a/src/components/SettingsForm.vue
+++ b/src/components/SettingsForm.vue
@@ -272,6 +272,9 @@
 		<p class="settings-hint">
 			{{ t('user_oidc', 'By default every user will get a unique user ID that is a hashed value of the provider and user ID. This can be turned off but uniqueness of users accross multiple user backends and providers is no longer preserved then.') }}
 		</p>
+		<NcNoteCard v-if="!localProvider.settings.uniqueUid" type="warning">
+			{{ t('user_oidc', 'Keep in mind that disabling "Unique user IDs" means that this provider can produce user IDs that are identical to user IDs from other providers (and from other user backends if you are in non-auto-provisioning mode). This means this provider can be potentially used to authenticate as users from other providers/backends. This might be what you want to achieve. In any case, please make sure you trust this provider.') }}
+		</NcNoteCard>
 		<NcCheckboxRadioSwitch
 			v-model="localProvider.settings.providerBasedId"
 			wrapper-element="div">
@@ -352,12 +355,14 @@ import ChevronDownIcon from 'vue-material-design-icons/ChevronDown.vue'
 
 import NcCheckboxRadioSwitch from '@nextcloud/vue/components/NcCheckboxRadioSwitch'
 import NcButton from '@nextcloud/vue/components/NcButton'
+import NcNoteCard from '@nextcloud/vue/components/NcNoteCard'
 
 export default {
 	name: 'SettingsForm',
 	components: {
 		NcCheckboxRadioSwitch,
 		NcButton,
+		NcNoteCard,
 		AlertOutlineIcon,
 		CheckIcon,
 		ChevronRightIcon,


### PR DESCRIPTION
Disabling "unique user IDs" is useful in non-auto-provisioning mode (when users are provisioned by user_ldap for example) but we should still remind admins it allows the Oidc provider to provide users with any user ID so they need to be trusted. Anyway an Oidc provider should always be trusted.