### PR TITLE
More checks when getting an avatar from a URL

### DIFF
--- a/lib/Service/ProvisioningService.php
+++ b/lib/Service/ProvisioningService.php
@@ -446,7 +446,13 @@ class ProvisioningService {
 		if (filter_var($avatarAttribute, FILTER_VALIDATE_URL)) {
 			$client = $this->clientService->newClient();
 			try {
-				$avatarContent = $client->get($avatarAttribute)->getBody();
+				$response = $client->get($avatarAttribute);
+				$contentType = $response->getHeader('Content-Type')[0] ?? '';
+				if (!in_array($contentType, ['image/jpeg', 'image/png', 'image/gif'], true)) {
+					$this->logger->warning('Avatar response is not an image', ['content_type' => $contentType]);
+					return;
+				}
+				$avatarContent = $response->getBody();
 				if (is_resource($avatarContent)) {
 					$avatarContent = stream_get_contents($avatarContent);
 				}


### PR DESCRIPTION
More checks when getting an avatar from a URL.
We only accept image content type payloads when retrieving an avatar with a URL.