### PR TITLE
Fix avatar Content-Type parsing when getHeader() returns string

### DIFF
--- a/lib/Service/ProvisioningService.php
+++ b/lib/Service/ProvisioningService.php
@@ -447,14 +447,16 @@ class ProvisioningService {
 			$client = $this->clientService->newClient();
 			try {
 				$response = $client->get($avatarAttribute);
-				$ct = $response->getHeader('Content-Type') ?? '';
-	
+				$ct = $response->getHeader('Content-Type');
+
+				/** @psalm-suppress TypeDoesNotContainType */
 				if (is_array($ct)) {
 					$contentType = $ct[0] ?? '';
 				} else {
+					/** @psalm-suppress RedundantCast */
 					$contentType = (string)$ct;
 				}
-	
+
 				$contentType = strtolower(trim(explode(';', $contentType)[0]));
 
 				if (!in_array($contentType, ['image/jpeg', 'image/png', 'image/gif'], true)) {


### PR DESCRIPTION
closes #1301

### Summary
This PR fixes a regression introduced in commit bf6220e3834e5b9ba10574784c8d2fd35019d5a0 where OIDC avatar provisioning may fail if the HTTP client returns the Content-Type header as a string instead of an array.

### Problem
`ProvisioningService::setUserAvatar()` assumes that:

`$response->getHeader('Content-Type')`

always returns an array. In some environments (e.g. Nextcloud 32 with nginx + php-fpm), it returns a string. Indexing the result with [0] then extracts only the first character (e.g. "i" from "image/png"), causing valid images to be rejected.

### Solution
- Accept both string and array return types from getHeader('Content-Type')
- Normalize the value
- Strip optional parameters such as "; charset=..."
- Preserve strict validation against supported image MIME types

### Tested
- Nextcloud 32.0.3.2
- user_oidc 8.3.0
- nginx + php-fpm
- Avatar URL returning Content-Type: image/png

### Related commit
bf6220e3834e5b9ba10574784c8d2fd35019d5a0