### PR TITLE
Fix: Do not cache invalid discovery response

### DIFF
--- a/lib/Service/DiscoveryService.php
+++ b/lib/Service/DiscoveryService.php
@@ -50,7 +50,7 @@ class DiscoveryService {
 	}
 
 	public function obtainDiscovery(Provider $provider): array {
-		$cacheKey = 'discovery-' . $provider->getDiscoveryEndpoint();
+		$cacheKey = 'discovery-2-' . $provider->getDiscoveryEndpoint();
 		$cachedDiscovery = $this->cache->get($cacheKey);
 		if ($cachedDiscovery === null) {
 			$url = $provider->getDiscoveryEndpoint();


### PR DESCRIPTION
Do not cache the discovery response if it can't be decoded.

closes #1300