### PR TITLE
Canonicalize locale claim

### DIFF
--- a/lib/Service/ProvisioningService.php
+++ b/lib/Service/ProvisioningService.php
@@ -8,6 +8,7 @@
 namespace OCA\UserOIDC\Service;
 
 use InvalidArgumentException;
+use Locale;
 use OC\Accounts\AccountManager;
 use OCA\UserOIDC\AppInfo\Application;
 use OCA\UserOIDC\Db\UserMapper;
@@ -311,6 +312,9 @@ class ProvisioningService {
 		$this->logger->debug('Locale mapping event dispatched');
 		if ($event->hasValue()) {
 			$locale = $event->getValue();
+			// according to the RFC, the locale we get is in BCP47 format (for example, en-US or fr-CA)
+			// see https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+			$locale = Locale::canonicalize($locale);
 			$locales = $this->l10nFactory->findAvailableLocales();
 			$localeCodes = array_map(static function ($l) {
 				return $l['code'];


### PR DESCRIPTION
[The OpenID Connect spec](https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims) has the value of the `locale` claim formatted as a [BCP 47](https://www.rfc-editor.org/info/bcp47) language tag, e.g. `en-US` or `fr-CA`.

Nextcloud [expects](https://github.com/nextcloud/server/blob/v32.0.6/resources/locales.json) the locale in ICU format, e.g. `en_US` or `fr_CA`.

This change converts between the two formats during the user provisioning step.