### PR TITLE
Fix LdapService::isLdapDeletedUser check

### DIFF
--- a/lib/Service/LdapService.php
+++ b/lib/Service/LdapService.php
@@ -33,7 +33,7 @@ class LdapService {
 	 * @throws \Psr\Container\NotFoundExceptionInterface
 	 */
 	public function isLdapDeletedUser(IUser $user): bool {
-		if ($this->isLDAPEnabled()) {
+		if (!$this->isLDAPEnabled()) {
 			return false;
 		}
 


### PR DESCRIPTION
Make an early return to false if the user_ldap app is NOT enabled.