### PR TITLE
Emit UserCreatedEvent when creating the user in our backend

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -60,6 +60,7 @@ use OCP\Security\ICrypto;
 use OCP\Security\ISecureRandom;
 use OCP\Session\Exceptions\SessionNotAvailableException;
 use OCP\User\Events\BeforeUserLoggedInEvent;
+use OCP\User\Events\UserCreatedEvent;
 use OCP\User\Events\UserLoggedInEvent;
 use Psr\Log\LoggerInterface;
 use UnexpectedValueException;
@@ -595,6 +596,10 @@ class LoginController extends BaseOidcController {
 			// use potential user from other backend, create it in our backend if it does not exist
 			$provisioningResult = $this->provisioningService->provisionUser($userId, $providerId, $idTokenPayload, $existingUser);
 			$user = $provisioningResult['user'];
+			if ($existingUser === null) {
+				// we know we just created a user
+				$this->eventDispatcher->dispatchTyped(new UserCreatedEvent($user, ''));
+			}
 			$this->session->set('user_oidc.oidcUserData', $provisioningResult['userData']);
 		} else {
 			// when auto provision is disabled, we assume the user has been created by another user backend (or manually)


### PR DESCRIPTION
Can this have unexpected side effect?

The UserCreatedEvent is listened to in those places:

* https://github.com/nextcloud/server/blob/master/apps/dav/lib/Listener/UserEventsListener.php#L61
* https://github.com/nextcloud/server/blob/master/apps/files_external/lib/Service/MountCacheService.php#L68
* https://github.com/nextcloud/server/blob/master/apps/admin_audit/lib/Listener/UserManagementEventListener.php#L27
* https://github.com/nextcloud/server/blob/master/apps/encryption/lib/Listeners/UserEventsListener.php#L48