### PR TITLE
Add group whitelist check when authenticating with bearer token

### DIFF
--- a/lib/Service/ProvisioningService.php
+++ b/lib/Service/ProvisioningService.php
@@ -531,7 +531,7 @@ class ProvisioningService {
 		}
 	}
 
-	public function getSyncGroupsOfToken(int $providerId, object $idTokenPayload) {
+	public function getSyncGroupsOfToken(int $providerId, object $idTokenPayload): ?array {
 		$groupsAttribute = $this->providerService->getSetting($providerId, ProviderService::SETTING_MAPPING_GROUPS, 'groups');
 		$groupsData = $this->getClaimValues($idTokenPayload, $groupsAttribute, $providerId);
 

--- a/lib/User/Validator/IBearerTokenValidator.php
+++ b/lib/User/Validator/IBearerTokenValidator.php
@@ -23,6 +23,16 @@ interface IBearerTokenValidator {
 	public function isValidBearerToken(Provider $provider, string $bearerToken): ?string;
 
 	/**
+	 * Get the user attributes from the token
+	 * This is needed to check if the user is part of a whitelisted group when validating a bearer token
+	 *
+	 * @param Provider $provider
+	 * @param string $bearerToken
+	 * @return object
+	 */
+	public function getUserAttributes(Provider $provider, string $bearerToken): object;
+
+	/**
 	 * Selects the provisioning strategy for this validation method.
 	 * This is used, when auto_provision and bearerProvisioning are activated.
 	 *

--- a/lib/User/Validator/SelfEncodedValidator.php
+++ b/lib/User/Validator/SelfEncodedValidator.php
@@ -80,6 +80,13 @@ class SelfEncodedValidator implements IBearerTokenValidator {
 		return $uid ?: null;
 	}
 
+	public function getUserAttributes(Provider $provider, string $bearerToken): object {
+		// try to decode the bearer token
+		JWT::$leeway = 60;
+		$jwks = $this->discoveryService->obtainJWK($provider, $bearerToken);
+		return JWT::decode($bearerToken, $jwks);
+	}
+
 	public function getProvisioningStrategy(): string {
 		return SelfEncodedTokenProvisioning::class;
 	}

--- a/lib/User/Validator/UserInfoValidator.php
+++ b/lib/User/Validator/UserInfoValidator.php
@@ -32,6 +32,10 @@ class UserInfoValidator implements IBearerTokenValidator {
 		return $uid ?: null;
 	}
 
+	public function getUserAttributes(Provider $provider, string $bearerToken): object {
+		return (object)$this->userInfoService->userinfo($provider, $bearerToken);
+	}
+
 	public function getProvisioningStrategy(): string {
 		// TODO implement provisioning over user info endpoint
 		return '';


### PR DESCRIPTION
Make sure to apply the group whitelist check (if enabled) when validating a bearer token that is actually an OIDC access token.