### PR TITLE
Prepare 8.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 8.6.1 – 2026-03-10
+
+### Fixed
+
+- Fix UserCreatedEvent dispatch crashing when user is null (disable_account_creation is enabled) @solracsf [#1367](https://github.com/nextcloud/user_oidc/pull/1367)
+
 ## 8.6.0 – 2026-03-05
 
 ### Added

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -8,7 +8,7 @@
 	<name>OpenID Connect user backend</name>
 	<summary>Use an OpenID Connect backend to login to your Nextcloud</summary>
 	<description>Allows flexible configuration of an OIDC server as Nextcloud login user backend.</description>
-	<version>8.6.0</version>
+	<version>8.6.1</version>
 	<licence>agpl</licence>
 	<author>Roeland Jago Douma</author>
 	<author>Julius Härtl</author>


### PR DESCRIPTION
### Fixed

- Fix UserCreatedEvent dispatch crashing when user is null (disable_account_creation is enabled) @solracsf [#1367](https://github.com/nextcloud/user_oidc/pull/1367)
