### PR TITLE
fix: handle dot-containing claim names in nested claim resolution

### DIFF
--- a/lib/Service/ProvisioningService.php
+++ b/lib/Service/ProvisioningService.php
@@ -87,20 +87,10 @@ class ProvisioningService {
 		$alternatives = explode('|', $claimPath);
 
 		foreach ($alternatives as $altPath) {
-			$parts = explode('.', trim($altPath));
-			$value = $tokenPayload;
-
-			foreach ($parts as $part) {
-				if (is_object($value) && property_exists($value, $part)) {
-					$value = $value->{$part};
-				} elseif (is_array($value) && array_key_exists($part, $value)) {
-					$value = $value[$part];
-				} else {
-					continue 2;
-				}
+			$result = $this->resolveNestedClaim($tokenPayload, trim($altPath));
+			if ($result !== null) {
+				return $result;
 			}
-
-			return $value;
 		}
 
 		return null;
@@ -113,6 +103,50 @@ class ProvisioningService {
 	public function getClaimValue(object|array $tokenPayload, string $claimPath, int $providerId): mixed {
 		$value = $this->getClaimValues($tokenPayload, $claimPath, $providerId);
 		return is_string($value) ? $value : null;
+	}
+
+	/**
+	 * Resolves a claim path against a token payload using greedy longest-prefix matching.
+	 *
+	 * Instead of splitting on every dot (which breaks URL-based claim names like
+	 * "https://idp.example.com/claims/groups" or literal dot keys like "user.role"),
+	 * this method first tries the full path as a literal key, then progressively
+	 * shorter dot-delimited prefixes (longest first), recursing into the remainder.
+	 */
+	private function resolveNestedClaim(object|array $data, string $path): mixed {
+		if ($path === '') {
+			return null;
+		}
+
+		// Try full path as literal key
+		if (is_object($data) && property_exists($data, $path)) {
+			return $data->{$path};
+		} elseif (is_array($data) && array_key_exists($path, $data)) {
+			return $data[$path];
+		}
+
+		// Try progressively shorter dot-prefixes (longest first)
+		$lastDot = strlen($path);
+		while (($lastDot = strrpos($path, '.', -(strlen($path) - $lastDot + 1))) !== false) {
+			$prefix = substr($path, 0, $lastDot);
+			$remainder = substr($path, $lastDot + 1);
+
+			$prefixValue = null;
+			if (is_object($data) && property_exists($data, $prefix)) {
+				$prefixValue = $data->{$prefix};
+			} elseif (is_array($data) && array_key_exists($prefix, $data)) {
+				$prefixValue = $data[$prefix];
+			}
+
+			if ($prefixValue !== null && (is_object($prefixValue) || is_array($prefixValue))) {
+				$result = $this->resolveNestedClaim($prefixValue, $remainder);
+				if ($result !== null) {
+					return $result;
+				}
+			}
+		}
+
+		return null;
 	}
 
 	/**

--- a/tests/unit/Service/ProvisioningServiceTest.php
+++ b/tests/unit/Service/ProvisioningServiceTest.php
@@ -293,6 +293,112 @@ class ProvisioningServiceTest extends TestCase {
 		);
 	}
 
+	public static function dataGetClaimValues(): array {
+		return [
+			'flat simple key' => [
+				'email',
+				(object)['email' => 'alice@example.com'],
+				'alice@example.com',
+			],
+			'nested via dot' => [
+				'custom.nickname',
+				(object)['custom' => (object)['nickname' => 'alice']],
+				'alice',
+			],
+			'URL-based flat key' => [
+				'https://idp.example.com/claims/groups',
+				(object)['https://idp.example.com/claims/groups' => ['admin', 'users']],
+				['admin', 'users'],
+			],
+			'URL key with nested navigation' => [
+				'https://idp.example.com/attrs.role',
+				(object)['https://idp.example.com/attrs' => (object)['role' => 'admin']],
+				'admin',
+			],
+			'URL key with dotted sub-key' => [
+				'https://idp.example.com/attrs.user.role',
+				(object)['https://idp.example.com/attrs' => (object)['user.role' => 'admin']],
+				'admin',
+			],
+			'deep nesting three levels' => [
+				'a.b.c',
+				(object)['a' => (object)['b' => (object)['c' => 'deep']]],
+				'deep',
+			],
+			'pipe fallback first match' => [
+				'missing | email',
+				(object)['email' => 'bob@example.com'],
+				'bob@example.com',
+			],
+			'pipe fallback second match' => [
+				'primary_email | email',
+				(object)['primary_email' => 'first@example.com', 'email' => 'second@example.com'],
+				'first@example.com',
+			],
+			'non-existent path returns null' => [
+				'does.not.exist',
+				(object)['other' => 'value'],
+				null,
+			],
+			'empty path returns null' => [
+				'',
+				(object)['key' => 'value'],
+				null,
+			],
+			'literal dot key takes precedence over nested' => [
+				'a.b',
+				(object)['a.b' => 'flat', 'a' => (object)['b' => 'nested']],
+				'flat',
+			],
+			'array payload' => [
+				'user.name',
+				['user' => ['name' => 'alice']],
+				'alice',
+			],
+			'URL key as array payload' => [
+				'https://idp.example.com/claims/roles',
+				['https://idp.example.com/claims/roles' => ['editor']],
+				['editor'],
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider dataGetClaimValues
+	 */
+	public function testGetClaimValues(string $claimPath, object|array $tokenPayload, mixed $expected): void {
+		$providerId = 1;
+
+		$this->providerService
+			->method('getSetting')
+			->will($this->returnValueMap([
+				[$providerId, ProviderService::SETTING_RESOLVE_NESTED_AND_FALLBACK_CLAIMS_MAPPING, '0', '1'],
+			]));
+
+		$result = $this->provisioningService->getClaimValues($tokenPayload, $claimPath, $providerId);
+		$this->assertEquals($expected, $result);
+	}
+
+	public function testGetClaimValuesWithoutNestedResolution(): void {
+		$providerId = 1;
+
+		$this->providerService
+			->method('getSetting')
+			->will($this->returnValueMap([
+				[$providerId, ProviderService::SETTING_RESOLVE_NESTED_AND_FALLBACK_CLAIMS_MAPPING, '0', '0'],
+			]));
+
+		// With nested resolution disabled, dot-containing keys should still work as literal keys
+		$payload = (object)['https://idp.example.com/claims/groups' => ['admin']];
+		$result = $this->provisioningService->getClaimValues($payload, 'https://idp.example.com/claims/groups', $providerId);
+		$this->assertEquals(['admin'], $result);
+
+		// But nested navigation should NOT work
+		$payload = (object)['custom' => (object)['nickname' => 'alice']];
+		$result = $this->provisioningService->getClaimValues($payload, 'custom.nickname', $providerId);
+		$this->assertNull($result);
+	}
+
 	public static function dataProvisionUserGroups() {
 		return [
 			[


### PR DESCRIPTION
## Summary

When `--resolve-nested-claims=1` is enabled, `getClaimValues()` uses `explode('.')` to split claim paths. This breaks for:

1. **URL-based claim names** (valid per [OIDC Core §5.1.2](https://openid.net/specs/openid-connect-core-1_0.html#AdditionalClaims)): `https://idp.example.com/claims/groups` gets split at hostname dots
2. **Object keys with literal dots**: `{"user.role": "admin"}` gets interpreted as nested navigation

### Approach: greedy longest-prefix matching

Replace `explode('.')` with a recursive resolver (`resolveNestedClaim()`) that:
1. Tries the **full remaining path as a literal key** first
2. Then tries progressively **shorter dot-prefixed segments** (longest first)
3. Recurses into the remainder when a prefix matches a nested object/array

This preserves full backward compatibility — existing dot-separated nested paths resolve identically since the algorithm falls through to the same splits.

### Examples

| Claim path | Token payload | Result |
|---|---|---|
| `https://idp.example.com/claims/groups` | `{"https://...groups": ["admin"]}` | `["admin"]` |
| `https://idp.example.com/attrs.role` | `{"https://...attrs": {"role": "admin"}}` | `"admin"` |
| `https://idp.example.com/attrs.user.role` | `{"https://...attrs": {"user.role": "admin"}}` | `"admin"` |
| `custom.nickname` | `{"custom": {"nickname": "alice"}}` | `"alice"` (backward compat) |
| `a.b` | `{"a.b": "flat", "a": {"b": "nested"}}` | `"flat"` (literal key precedence) |

Fixes #1373
Related: #1100

## Test plan

- [x] Added 13 data-provider test cases covering: flat keys, nested keys, URL claim names, URL + nested navigation, URL + dotted sub-keys, deep nesting, pipe fallbacks, non-existent paths, empty paths, literal dot key precedence, array payloads
- [x] Added regression test for flat mode (nested resolution disabled)
- [ ] CI phpunit pass