### PR TITLE
fix: set IUserSession user after bearer token validation

### DIFF
--- a/lib/User/Backend.php
+++ b/lib/User/Backend.php
@@ -36,6 +36,7 @@ use OCP\ISession;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
+use OCP\IUserSession;
 use OCP\Server;
 use OCP\ServerVersion;
 use OCP\User\Backend\ABackend;
@@ -344,10 +345,12 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 							}
 
 							$this->session->set('last-password-confirm', strtotime('+4 year', time()));
+							$this->setSessionUser($userId);
 							return $userId;
 						} elseif ($this->userExists($tokenUserId)) {
 							$this->checkFirstLogin($tokenUserId);
 							$this->session->set('last-password-confirm', strtotime('+4 year', time()));
+							$this->setSessionUser($tokenUserId);
 							return $tokenUserId;
 						} else {
 							// check if the user exists locally
@@ -369,6 +372,7 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 							}
 							$this->checkFirstLogin($tokenUserId);
 							$this->session->set('last-password-confirm', strtotime('+4 year', time()));
+							$this->setSessionUser($tokenUserId);
 							return $tokenUserId;
 						}
 					}
@@ -378,6 +382,26 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 
 		$this->logger->debug('Could not find unique token validation');
 		return '';
+	}
+
+	/**
+	 * Set the user in IUserSession after bearer token validation.
+	 * Without this, DI-injected $userId is null in OCS controllers
+	 * and CalDAV plugins, causing 500 errors in Deck, Talk, and Tasks.
+	 *
+	 * Note: IUserSession is resolved via Server::get() rather than constructor
+	 * injection to avoid a circular dependency (IUserSession depends on this Backend).
+	 */
+	private function setSessionUser(string $userId): void {
+		try {
+			$user = $this->userManager->get($userId);
+			if ($user !== null) {
+				$userSession = Server::get(IUserSession::class);
+				$userSession->setUser($user);
+			}
+		} catch (Throwable $e) {
+			$this->logger->debug('Failed to set session user after bearer validation: ' . $e->getMessage());
+		}
 	}
 
 	/**

--- a/lib/User/Backend.php
+++ b/lib/User/Backend.php
@@ -394,12 +394,17 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 	 */
 	private function setSessionUser(string $userId): void {
 		try {
-			$user = $this->userManager->get($userId);
-			if ($user !== null) {
-				$userSession = Server::get(IUserSession::class);
-				$userSession->setUser($user);
+			$userSession = Server::get(IUserSession::class);
+			$currentUser = $userSession->getUser();
+
+			// Only fetch and set if the session doesn't already have this user
+			if ($currentUser === null || $currentUser->getUID() !== $userId) {
+				$user = $this->userManager->get($userId);
+				if ($user !== null) {
+					$userSession->setUser($user);
+				}
 			}
-		} catch (Throwable $e) {
+		} catch (\Throwable $e) {
 			$this->logger->debug('Failed to set session user after bearer validation: ' . $e->getMessage());
 		}
 	}


### PR DESCRIPTION
## Summary                                                  
   
  When user_oidc validates a bearer token in Backend::getCurrentUserId(), it returns the correct userId but does not call IUserSession::setUser().    
  This leaves the user session in an inconsistent state where getCurrentUserId() succeeds but DI-injected $userId parameters remain null.          

  ## Problem

  OCS controllers and CalDAV plugins that receive $userId via dependency injection get null instead of the authenticated user's ID when the request
  is authenticated via OIDC bearer token. This causes:

  - **Deck**: TypeError: ...$userId must be of type string, null given
  - **Talk**: Same TypeError pattern
  - **Tasks** (CalDAV): 500 errors from null userId

  These apps work correctly with session-based OIDC login (where setUser() IS called) but fail with bearer token authentication.

  ## Fix

  Call IUserSession::setUser() after successful bearer token validation at all three return points in getCurrentUserId(). IUserSession is resolved via
   Server::get() rather than constructor injection to avoid a circular dependency.

  ## Testing

  1. Configure an OIDC provider with bearer token validation enabled
  2. Make API requests to Deck, Talk, or CalDAV endpoints using a bearer token
  3. Verify 200 responses instead of 500 errors