### PR TITLE
perf(ldap): Optimize check if LDAP user is deleted

### DIFF
--- a/lib/Service/LdapService.php
+++ b/lib/Service/LdapService.php
@@ -48,6 +48,10 @@ class LdapService {
 			return false;
 		}
 
+		if (!$dui->isUserMarked($user->getUID())) {
+			return false;
+		}
+
 		if (!$dui->hasUsers()) {
 			return false;
 		}

--- a/tests/stubs/oca_user_ldap.php
+++ b/tests/stubs/oca_user_ldap.php
@@ -26,6 +26,9 @@ class DeletedUsersIndex {
 	public function getUsers(): array {
 		return [];
 	}
+
+	public function isUserMarked(string $uid): bool {
+	}
 }
 
 namespace OCA\User_LDAP;


### PR DESCRIPTION
Check first if the current user is deleted, before loading all the deleted users and checking if their deletion is still up-to-date.

Allow to abort early for non-deleted users.

`isUserMarked` is available since NC 28