### PR TITLE
fix(login): treat already-logged-out as success in backchannel logout (#1430)

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -930,11 +930,19 @@ class LoginController extends BaseOidcController {
 			try {
 				$oidcSession = $this->sessionMapper->findSessionBySid($sid, $sub, $iss);
 			} catch (DoesNotExistException $e) {
-				return $this->getBackchannelLogoutErrorResponse(
-					$sub === null ? 'invalid SID or ISS' : 'invalid SID, SUB or ISS',
-					$sub === null ? 'No session was found for this (sid,iss)' : 'No session was found for this (sid,sub,iss)',
-					['session_not_found' => $sid]
+				// Per OIDC Backchannel Logout 1.0 §2.6:
+				// "If the identified End-User is already logged out at the
+				// RP when the logout request is received, the logout is
+				// considered to have succeeded." Returning 400 here
+				// causes IdPs (e.g. LemonLDAP, Keycloak) to surface a
+				// confusing error to the user even though the desired
+				// state — the RP session being gone — is already true.
+				// See https://openid.net/specs/openid-connect-backchannel-1_0.html#BCActions
+				$this->logger->debug(
+					'[BackchannelLogout] no RP session for (sid,iss) — treating as already-logged-out per spec',
+					['sid' => $sid, 'sub_present' => $sub !== null]
 				);
+				return new JSONResponse([], Http::STATUS_OK);
 			} catch (MultipleObjectsReturnedException $e) {
 				return $this->getBackchannelLogoutErrorResponse(
 					$sub === null ? 'invalid SID or ISS' : 'invalid SID, SUB or ISS',
@@ -957,11 +965,14 @@ class LoginController extends BaseOidcController {
 			}
 
 			if (empty($oidcSessionsToKill)) {
-				return $this->getBackchannelLogoutErrorResponse(
-					'nothing found with sub+iss',
-					'No session found with sub+iss',
-					['sub_iss_no_session_found' => true]
+				// Per OIDC Backchannel Logout 1.0 §2.6 (already-logged-
+				// out is a success). Same rationale as the (sid,iss)
+				// branch above.
+				$this->logger->debug(
+					'[BackchannelLogout] no RP sessions for (sub,iss) — treating as already-logged-out per spec',
+					['sub' => $sub]
 				);
+				return new JSONResponse([], Http::STATUS_OK);
 			}
 		}
 

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -930,16 +930,10 @@ class LoginController extends BaseOidcController {
 			try {
 				$oidcSession = $this->sessionMapper->findSessionBySid($sid, $sub, $iss);
 			} catch (DoesNotExistException $e) {
-				// Per OIDC Backchannel Logout 1.0 §2.6:
-				// "If the identified End-User is already logged out at the
-				// RP when the logout request is received, the logout is
-				// considered to have succeeded." Returning 400 here
-				// causes IdPs (e.g. LemonLDAP, Keycloak) to surface a
-				// confusing error to the user even though the desired
-				// state — the RP session being gone — is already true.
-				// See https://openid.net/specs/openid-connect-backchannel-1_0.html#BCActions
+				// Already-logged-out is a success per OIDC Backchannel Logout 1.0 §2.6.
+				// https://openid.net/specs/openid-connect-backchannel-1_0.html#BCActions
 				$this->logger->debug(
-					'[BackchannelLogout] no RP session for (sid,iss) — treating as already-logged-out per spec',
+					'[BackchannelLogout] no RP session for (sid,iss) — treating as already-logged-out',
 					['sid' => $sid, 'sub_present' => $sub !== null]
 				);
 				return new JSONResponse([], Http::STATUS_OK);
@@ -965,11 +959,9 @@ class LoginController extends BaseOidcController {
 			}
 
 			if (empty($oidcSessionsToKill)) {
-				// Per OIDC Backchannel Logout 1.0 §2.6 (already-logged-
-				// out is a success). Same rationale as the (sid,iss)
-				// branch above.
+				// Already-logged-out is a success per OIDC Backchannel Logout 1.0 §2.6.
 				$this->logger->debug(
-					'[BackchannelLogout] no RP sessions for (sub,iss) — treating as already-logged-out per spec',
+					'[BackchannelLogout] no RP sessions for (sub,iss) — treating as already-logged-out',
 					['sub' => $sub]
 				);
 				return new JSONResponse([], Http::STATUS_OK);


### PR DESCRIPTION
Closes #1430.

## Summary
Per [OIDC Backchannel Logout 1.0 §2.6](https://openid.net/specs/openid-connect-backchannel-1_0.html#BCActions):

> If the identified End-User is already logged out at the RP when the logout request is received, the logout is considered to have succeeded.

Today `backChannelLogout()` returns **HTTP/400** when the `(sid, iss)` or `(sub, iss)` lookup yields no matching session, which is exactly the already-logged-out case the spec calls out as a **success**. The reporter (running LemonLDAP) sees a confusing error surfaced on the IdP UI even though the desired state — the RP session being gone — is already true. The same shape would happen with Keycloak, Authelia, etc.

## Change
Only the two \"session not found\" paths flip to HTTP/200:

- `findSessionBySid` → `DoesNotExistException` ⇒ return `HTTP/200 OK` + debug log.
- `findSessionsBySubAndIss` returns empty ⇒ return `HTTP/200 OK` + debug log.

The other validation branches in the same method — invalid issuer, invalid signature, malformed token, missing claims, multiple-sessions-found — keep their HTTP/400 responses. Operators that need visibility into already-logged-out backchannel calls can flip Nextcloud's `loglevel` to `debug` and see the `[BackchannelLogout]` line.

Mirrors the proposed fix in the issue and the spec citation.

## Test plan
- No `LoginControllerTest` exists in `tests/unit/Controller/` today, and the existing integration runner under `tests/integration/` does not cover the backchannel flow. The change is two short branches that swap a `getBackchannelLogoutErrorResponse()` for `new JSONResponse([], Http::STATUS_OK)` plus a debug log; both branches are *syntactically* equivalent to the existing `return new JSONResponse([], Http::STATUS_OK)` at the end of the success path.
- Ran `git diff --check` clean.
- Verified the spec citation against the linked RFC section.

## Notes
- This is the spec-compliant behavior; existing IdPs will start receiving cleaner success responses for the already-logged-out case.
- The optional \"debug checkbox\" the reporter floated is left for follow-up — the spec is unambiguous, so a per-provider opt-out adds configuration surface for no clear benefit.