### PR TITLE
Fix: Make exp claim required for back-channel logout

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -959,7 +959,7 @@ class LoginController extends BaseOidcController {
 			);
 		}
 
-		if ($logoutTokenPayload->exp < $this->timeFactory->getTime()) {
+		if (($logoutTokenPayload->exp ?? 0) < $this->timeFactory->getTime()) {
 			return  $this->getBackchannelLogoutErrorResponse(
 				'invalid exp',
 				'The logout token is expired',

--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -889,8 +889,7 @@ class LoginController extends BaseOidcController {
 
 		// REQUIRED claims check step
 		// https://openid.net/specs/openid-connect-backchannel-1_0.html#LogoutToken
-		// Note : exp claim is deliberately not checked. See #1432
-		$requiredClaims = ['iss', 'aud', 'iat', 'jti', 'events'];
+		$requiredClaims = ['iss', 'aud', 'iat', 'exp', 'jti', 'events'];
 		$missingClaims = [];
 		$logoutTokenArray = (array)$logoutTokenPayload;
 		foreach ($requiredClaims as $claim) {
@@ -960,7 +959,7 @@ class LoginController extends BaseOidcController {
 			);
 		}
 
-		if (isset($logoutTokenPayload->exp) && $logoutTokenPayload->exp < $this->timeFactory->getTime()) {
+		if ($logoutTokenPayload->exp < $this->timeFactory->getTime()) {
 			return  $this->getBackchannelLogoutErrorResponse(
 				'invalid exp',
 				'The logout token is expired',


### PR DESCRIPTION
fixes #1436 

This reverts commit 7fcb03d5cb20a4cb7ed8e076a1fd5a4e19d8232d.

The exp claim in the logout token during back-channel logout was not checked due to LemonLDAP (third party IdP) not including it. LemonLDAP's users would have been unable to logout with back-channel.

Now that the fix is merged, the commit can be reverted.
