### PR TITLE
fix: Check group allow list based on the display name

### DIFF
--- a/lib/Service/ProvisioningService.php
+++ b/lib/Service/ProvisioningService.php
@@ -762,13 +762,22 @@ class ProvisioningService {
 			return null;
 		}
 
-		$userGroups = $this->groupManager->getUserGroupIds($user);
-		foreach ($userGroups as $groupGID) {
-			if (!in_array($groupGID, array_column($syncGroups, 'gid'))) {
-				if ($groupsWhitelistRegex && !preg_match($groupsWhitelistRegex, $groupGID)) {
-					continue;
+		if ($groupsWhitelistRegex) {
+			$userGroups = $this->groupManager->getUserGroups($user);
+			foreach ($userGroups as $group) {
+				if (!in_array($group->getGID(), array_column($syncGroups, 'gid'))) {
+					if (!preg_match($groupsWhitelistRegex, $group->getDisplayName())) {
+						continue;
+					}
+					$group->removeUser($user);
 				}
-				$this->groupManager->get($groupGID)?->removeUser($user);
+			}
+		} else {
+			$userGroupIds = $this->groupManager->getUserGroupIds($user);
+			foreach ($userGroupIds as $groupGID) {
+				if (!in_array($groupGID, array_column($syncGroups, 'gid'))) {
+					$this->groupManager->get($groupGID)?->removeUser($user);
+				}
 			}
 		}
 


### PR DESCRIPTION
Since a few versions ago, we use ICreateNamedGroupBackend to create group on the default database backend. This will use the display name as GID unless the display name is too long and in that case will use a random GID.

This random GID is impossible to match with the regex.

Fix #1472 

Thanks to @OScaleSven for the initial research :)


## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
