### PR TITLE
fix: don't set session user in getCurrentUserId

### DIFF
--- a/lib/User/Backend.php
+++ b/lib/User/Backend.php
@@ -37,7 +37,6 @@ use OCP\ISession;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IUserManager;
-use OCP\IUserSession;
 use OCP\Server;
 use OCP\User\Backend\ABackend;
 use OCP\User\Backend\ICountUsersBackend;
@@ -369,12 +368,10 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 							}
 
 							$this->session->set('last-password-confirm', $this->timeFactory->getTime() + 4 * 365 * 24 * 3600);
-							$this->setSessionUser($userId);
 							return $userId;
 						} elseif ($this->userExists($tokenUserId)) {
 							$this->checkFirstLogin($tokenUserId);
 							$this->session->set('last-password-confirm', $this->timeFactory->getTime() + 4 * 365 * 24 * 3600);
-							$this->setSessionUser($tokenUserId);
 							return $tokenUserId;
 						} else {
 							// check if the user exists locally
@@ -396,7 +393,6 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 							}
 							$this->checkFirstLogin($tokenUserId);
 							$this->session->set('last-password-confirm', $this->timeFactory->getTime() + 4 * 365 * 24 * 3600);
-							$this->setSessionUser($tokenUserId);
 							return $tokenUserId;
 						}
 					}
@@ -415,31 +411,6 @@ class Backend extends ABackend implements IPasswordConfirmationBackend, IGetDisp
 	 */
 	private function isAcceptableUserId(mixed $userId): bool {
 		return is_string($userId) && $userId !== '' && trim($userId) !== '';
-	}
-
-	/**
-	 * Set the user in IUserSession after bearer token validation.
-	 * Without this, DI-injected $userId is null in OCS controllers
-	 * and CalDAV plugins, causing 500 errors in Deck, Talk, and Tasks.
-	 *
-	 * Note: IUserSession is resolved via Server::get() rather than constructor
-	 * injection to avoid a circular dependency (IUserSession depends on this Backend).
-	 */
-	private function setSessionUser(string $userId): void {
-		try {
-			$userSession = Server::get(IUserSession::class);
-			$currentUser = $userSession->getUser();
-
-			// Only fetch and set if the session doesn't already have this user
-			if ($currentUser === null || $currentUser->getUID() !== $userId) {
-				$user = $this->userManager->get($userId);
-				if ($user !== null) {
-					$userSession->setUser($user);
-				}
-			}
-		} catch (\Throwable $e) {
-			$this->logger->debug('Failed to set session user after bearer validation: ' . $e->getMessage());
-		}
 	}
 
 	/**

--- a/tests/unit/User/BackendTest.php
+++ b/tests/unit/User/BackendTest.php
@@ -1,0 +1,233 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+use OCA\UserOIDC\AppInfo\Application;
+use OCA\UserOIDC\Db\Provider;
+use OCA\UserOIDC\Db\ProviderMapper;
+use OCA\UserOIDC\Db\UserMapper;
+use OCA\UserOIDC\Service\DiscoveryService;
+use OCA\UserOIDC\Service\LdapService;
+use OCA\UserOIDC\Service\ProviderService;
+use OCA\UserOIDC\Service\ProvisioningService;
+use OCA\UserOIDC\User\Backend;
+use OCA\UserOIDC\User\Validator\SelfEncodedValidator;
+use OCP\AppFramework\Utility\ITimeFactory;
+use OCP\EventDispatcher\IEventDispatcher;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\ISession;
+use OCP\IURLGenerator;
+use OCP\IUser;
+use OCP\IUserManager;
+use OCP\IUserSession;
+use OCP\Server;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Regression tests for the bearer token path of the IApacheBackend implementation.
+ *
+ * getCurrentUserId() runs as the very first statement of OC_User::loginWithApache(),
+ * which then guards the whole login block on the session user not being set yet:
+ *
+ *     $uid = $backend->getCurrentUserId();
+ *     if ($uid) {
+ *         if (self::getUser() !== $uid) {          // <- closed if we set the user above
+ *             self::setUserId($uid);
+ *             ...
+ *             $userSession->createSessionToken($request, $uid, $uid, $password);
+ *
+ * OC_User::getUser() reads the session key 'user_id', which is exactly what
+ * IUserSession::setUser() writes. So setting the session user from inside
+ * getCurrentUserId() closes that guard and no oc_authtoken row is ever written for
+ * the request, which breaks every endpoint that needs a session token afterwards.
+ *
+ * The backend must therefore only *resolve* the user and leave logging them in to
+ * the server. Note that setVolatileActiveUser() is deliberately not covered here:
+ * it does not persist 'user_id' and so does not close the guard.
+ *
+ * @see https://github.com/nextcloud/user_oidc/issues/1452
+ *
+ * Extends \Test\TestCase (not PHPUnit's) for overwriteService(), because the backend
+ * resolves IUserSession and the token validators through Server::get().
+ */
+class BackendTest extends \Test\TestCase {
+	private const TOKEN_USER_ID = 'oidc-token-user';
+	private const PROVIDER_ID = 1;
+
+	private IConfig&MockObject $config;
+	private UserMapper&MockObject $userMapper;
+	private LoggerInterface&MockObject $logger;
+	private IRequest&MockObject $request;
+	private ISession&MockObject $session;
+	private IURLGenerator&MockObject $urlGenerator;
+	private IEventDispatcher&MockObject $eventDispatcher;
+	private DiscoveryService&MockObject $discoveryService;
+	private ProviderMapper&MockObject $providerMapper;
+	private ProviderService&MockObject $providerService;
+	private ProvisioningService&MockObject $provisioningService;
+	private LdapService&MockObject $ldapService;
+	private IUserManager&MockObject $userManager;
+	private ITimeFactory&MockObject $timeFactory;
+
+	private Backend $backend;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->userMapper = $this->createMock(UserMapper::class);
+		$this->logger = $this->createMock(LoggerInterface::class);
+		$this->request = $this->createMock(IRequest::class);
+		$this->session = $this->createMock(ISession::class);
+		$this->urlGenerator = $this->createMock(IURLGenerator::class);
+		$this->eventDispatcher = $this->createMock(IEventDispatcher::class);
+		$this->discoveryService = $this->createMock(DiscoveryService::class);
+		$this->providerMapper = $this->createMock(ProviderMapper::class);
+		$this->providerService = $this->createMock(ProviderService::class);
+		$this->provisioningService = $this->createMock(ProvisioningService::class);
+		$this->ldapService = $this->createMock(LdapService::class);
+		$this->userManager = $this->createMock(IUserManager::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
+
+		$this->backend = new Backend(
+			$this->config,
+			$this->userMapper,
+			$this->logger,
+			$this->request,
+			$this->session,
+			$this->urlGenerator,
+			$this->eventDispatcher,
+			$this->discoveryService,
+			$this->providerMapper,
+			$this->providerService,
+			$this->provisioningService,
+			$this->ldapService,
+			$this->userManager,
+			$this->timeFactory,
+		);
+	}
+
+	/**
+	 * Auto-provisioning enabled (the default): the user already exists, so it is
+	 * reused instead of being created.
+	 */
+	public function testBearerAuthWithAutoProvisioningDoesNotLogTheUserIn(): void {
+		$this->givenAValidBearerToken();
+
+		$user = $this->givenAUserThatHasLoggedInBefore(self::TOKEN_USER_ID);
+		$this->userManager->method('userExists')->with(self::TOKEN_USER_ID)->willReturn(true);
+		$this->userManager->method('get')->with(self::TOKEN_USER_ID)->willReturn($user);
+		$this->ldapService->method('isLdapDeletedUser')->with($user)->willReturn(false);
+
+		$this->assertResolvesUserWithoutLoggingIn(self::TOKEN_USER_ID);
+	}
+
+	/**
+	 * Auto-provisioning disabled and the user is known to this backend.
+	 */
+	public function testBearerAuthWithoutAutoProvisioningDoesNotLogTheUserIn(): void {
+		$this->givenAValidBearerToken(['auto_provision' => false]);
+
+		$user = $this->givenAUserThatHasLoggedInBefore(self::TOKEN_USER_ID);
+		$this->userMapper->method('userExists')->with(self::TOKEN_USER_ID)->willReturn(true);
+		$this->userManager->method('get')->with(self::TOKEN_USER_ID)->willReturn($user);
+
+		$this->assertResolvesUserWithoutLoggingIn(self::TOKEN_USER_ID);
+	}
+
+	/**
+	 * Auto-provisioning disabled and the user lives in another backend (for
+	 * instance synced from LDAP).
+	 */
+	public function testBearerAuthForUserOfAnotherBackendDoesNotLogTheUserIn(): void {
+		$this->givenAValidBearerToken(['auto_provision' => false]);
+
+		$user = $this->givenAUserThatHasLoggedInBefore(self::TOKEN_USER_ID);
+		$this->userMapper->method('userExists')->with(self::TOKEN_USER_ID)->willReturn(false);
+		$this->userManager->method('userExists')->with(self::TOKEN_USER_ID)->willReturn(true);
+		$this->userManager->method('get')->with(self::TOKEN_USER_ID)->willReturn($user);
+		$this->ldapService->method('isLdapDeletedUser')->with($user)->willReturn(false);
+
+		$this->assertResolvesUserWithoutLoggingIn(self::TOKEN_USER_ID);
+	}
+
+	/**
+	 * Wires up a request carrying a bearer token that the self encoded validator
+	 * accepts for a provider with bearer checking turned on.
+	 *
+	 * @param array<string, mixed> $systemConfig the 'user_oidc' system config
+	 */
+	private function givenAValidBearerToken(array $systemConfig = []): void {
+		$this->config->method('getSystemValue')->with('user_oidc', [])->willReturn($systemConfig);
+		$this->request->method('getHeader')
+			->with(Application::OIDC_API_REQ_HEADER)
+			->willReturn('Bearer a-valid-token');
+
+		$provider = new Provider();
+		$provider->setId(self::PROVIDER_ID);
+		$provider->setIdentifier('test-provider');
+		$this->providerMapper->method('getProviders')->willReturn([$provider]);
+
+		$this->providerService->method('getSetting')->willReturnMap([
+			[self::PROVIDER_ID, ProviderService::SETTING_CHECK_BEARER, '0', '1'],
+			[self::PROVIDER_ID, ProviderService::SETTING_RESTRICT_LOGIN_TO_GROUPS, '0', '0'],
+			[self::PROVIDER_ID, ProviderService::SETTING_BEARER_PROVISIONING, '0', '0'],
+		]);
+
+		$this->discoveryService->method('obtainDiscovery')->willReturn([]);
+		$this->timeFactory->method('getTime')->willReturn(1700000000);
+
+		$validator = $this->createMock(SelfEncodedValidator::class);
+		$validator->method('isValidBearerToken')->willReturn(self::TOKEN_USER_ID);
+		$this->overwriteService(SelfEncodedValidator::class, $validator);
+	}
+
+	private function givenAUserThatHasLoggedInBefore(string $uid): IUser&MockObject {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn($uid);
+		// a non-zero last login keeps checkFirstLogin() away from the filesystem
+		$user->method('getLastLogin')->willReturn(1600000000);
+		$user->method('getBackendClassName')->willReturn(Application::APP_ID);
+
+		return $user;
+	}
+
+	/**
+	 * The regression: the bearer token must resolve to $expectedUserId without any
+	 * of it landing in the user session, so that OC_User::loginWithApache() still
+	 * runs createSessionToken() and the rest of the login.
+	 */
+	private function assertResolvesUserWithoutLoggingIn(string $expectedUserId): void {
+		$userSession = $this->createMock(IUserSession::class);
+		$userSession->expects($this->never())
+			->method('setUser');
+		$this->overwriteService(IUserSession::class, $userSession);
+		// without this the never() expectation above would hold vacuously and the
+		// test would stay green even with the session user being set
+		$this->assertSame(
+			$userSession,
+			Server::get(IUserSession::class),
+			'the IUserSession mock did not replace the real service'
+		);
+
+		$this->session->method('set')->willReturnCallback(
+			function (string $key, mixed $value): void {
+				$this->assertNotSame(
+					'user_id',
+					$key,
+					'getCurrentUserId() must not put the user into the session: OC_User::loginWithApache() '
+					. 'then skips createSessionToken() and the request gets no auth token.'
+				);
+			}
+		);
+
+		$this->assertSame($expectedUserId, $this->backend->getCurrentUserId());
+	}
+}


### PR DESCRIPTION
Fixes #1452

## Problem

`setSessionUser()`, added in #1376, is called from the first line of `getCurrentUserId()`. `loginWithApache()` guards its whole login block on the active user not already being set:

```php
$uid = $backend->getCurrentUserId();
if ($uid) {
    if (self::getUser() !== $uid) {     // <- guard
        ...
        $userSession->createSessionToken($request, $uid, $uid, $password);
        $userSession->createRememberMeToken($userSession->getUser());
        // token scopes, setupFS, post_login hook, UserLoggedInEvent
    }
    return true;
}
```

`IUserSession::setUser()` persists `user_id` into the session, so by the time control reaches the guard it's already satisfied and the entire block is skipped. No `oc_authtoken` row is ever created for that session.

## Impact

Not just app passwords (#1452's original symptom). `Session::validateSession()` looks up a token by session id on every request that reuses the session cookie; with no row to find, it calls `logout()`, which strips the cookie. A client that authenticates once with a bearer token and relies on the cookie for follow-up requests gets a 401 on the very next request.

Confirmed independently on master and `8.11.0-dev`: bearer request then cookie-only request goes `200` → `401` with the calls in place, `200` → `200` with them removed.

DAV also reaches this code, through its own `handleApacheAuth()` call site in `apps/dav/lib/Connector/Sabre/Auth.php`, separate from `OC::handleLogin()`. Confirmed `207` both before and after this change.

## Why a revert

`getCurrentUserId()` is called before `loginWithApache()`'s guard, and there's no hook in between — nothing the app does inside `getCurrentUserId()` can both satisfy the guard and leave a token row behind, since satisfying the guard *is* what skips the code that creates the row. A "complete the login inside the app" approach was considered and dropped: it only works by keeping the guard closed on purpose, which means maintaining a parallel login path here that has to keep tracking core's.

The `setupFS`/keygen cost this avoided is real, but it's a separate, filed issue — after this revert, every bearer request without a session cookie re-pays it, same as before #1376.

## Testing

`composer lint && composer cs:check && composer psalm` clean, no baseline changes.

No unit test added — `tests/unit/` has no existing coverage of `Backend.php`, and this is only observable end-to-end (bearer request → cookie reuse), which needs a running server, not a unit fixture.