### PR TITLE
feat(user_oidc): Add provider_id/sub columns and getByProviderAndSub()

### DIFF
--- a/lib/Controller/OcsApiController.php
+++ b/lib/Controller/OcsApiController.php
@@ -34,7 +34,7 @@ class OcsApiController extends OCSController {
 	 * Create or update a user for a backend provider.
 	 *
 	 * @param int $providerId Numeric ID of the provider backend
-	 * @param string $userId Provider-specific user identifier
+	 * @param non-empty-string $userId Provider-specific user identifier
 	 * @param string|null $displayName Optional display name to set for the user
 	 * @param string|null $email Optional email address to set for the user
 	 * @param string|null $quota Optional quota value to set for the user

--- a/lib/Db/User.php
+++ b/lib/Db/User.php
@@ -16,6 +16,10 @@ use OCP\DB\Types;
  * @method \void setUserId(string $userId)
  * @method \string getDisplayName()
  * @method \void setDisplayName(string $displayName)
+ * @method \int|null getProviderId()
+ * @method \void setProviderId(?int $providerId)
+ * @method \string|null getSub()
+ * @method \void setSub(?string $sub)
  */
 class User extends Entity {
 
@@ -25,8 +29,24 @@ class User extends Entity {
 	/** @var string */
 	protected $displayName;
 
+	/**
+	 * The provider this user was provisioned from, kept alongside the
+	 * (possibly hashed) userId so the same person can be recognized again
+	 * independently of the user_id-generation setting.
+	 * @var int|null
+	 */
+	protected $providerId;
+
+	/**
+	 * The OIDC subject claim this user was provisioned from. See $providerId.
+	 * @var string|null
+	 */
+	protected $sub;
+
 	public function __construct() {
 		$this->addType('userId', Types::STRING);
 		$this->addType('displayName', Types::STRING);
+		$this->addType('providerId', Types::INTEGER);
+		$this->addType('sub', Types::STRING);
 	}
 }

--- a/lib/Db/UserMapper.php
+++ b/lib/Db/UserMapper.php
@@ -152,7 +152,43 @@ class UserMapper extends QBMapper {
 		}
 	}
 
+	/**
+	 * @param non-empty-string $sub Sub of the user hashed if it exceed 256 characters
+	 * @throws \OCP\AppFramework\Db\DoesNotExistException
+	 * @throws \OCP\AppFramework\Db\MultipleObjectsReturnedException
+	 */
+	protected function getByProviderAndSub(int $providerId, string $sub): User {
+		$qb = $this->db->getQueryBuilder();
+		$qb->select('*')
+			->from($this->getTableName())
+			->where($qb->expr()->eq('provider_id', $qb->createNamedParameter($providerId, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->eq('sub', $qb->createNamedParameter($sub, IQueryBuilder::PARAM_STR)));
+
+		/** @var User $user */
+		$user = $this->findEntity($qb);
+		$this->userCache->set($user->getUserId(), $user);
+		return $user;
+	}
+
+	/**
+	 * @param non-empty-string $sub
+	 */
 	public function getOrCreate(int $providerId, string $sub, bool $id4me = false): User {
+		// the sub is the stable identifier we want to keep around, so guard it
+		// against the column length the same way the userId is further below
+		$storedSub = strlen($sub) > 256 ? hash('sha256', $sub) : $sub;
+
+		try {
+			// look this identity up by its immutable (provider, sub) pair
+			// first: if it has been provisioned before, this always returns
+			// its existing account, even if the uid-generation settings
+			// changed since - this is what keeps a provider's own attribute
+			// drift from forking the account into a second, empty one
+			return $this->getByProviderAndSub($providerId, $storedSub);
+		} catch (IMapperException $e) {
+			// not seen under this provider+sub yet, fall through below
+		}
+
 		$userId = $this->idService->getId($providerId, $sub, $id4me);
 
 		if (strlen($userId) > 64) {
@@ -160,7 +196,16 @@ class UserMapper extends QBMapper {
 		}
 
 		try {
-			return $this->getUser($userId);
+			$user = $this->getUser($userId);
+			if ($user->getProviderId() === null || $user->getSub() === null) {
+				// backfill accounts that were provisioned before these columns
+				// existed, so their next login takes the fast path above
+				$user->setProviderId($providerId);
+				$user->setSub($storedSub);
+				$user = $this->update($user);
+				$this->userCache->set($userId, $user);
+			}
+			return $user;
 		} catch (IMapperException $e) {
 			// just ignore and continue
 		}
@@ -168,6 +213,8 @@ class UserMapper extends QBMapper {
 		$user = new User();
 		$user->setUserId($userId);
 		$user->setDisplayName('');
+		$user->setProviderId($providerId);
+		$user->setSub($storedSub);
 		$user = $this->insert($user);
 		$this->userCache->set($userId, $user);
 		return $user;

--- a/lib/Migration/Version081100Date20260824120000.php
+++ b/lib/Migration/Version081100Date20260824120000.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+namespace OCA\UserOIDC\Migration;
+
+use Closure;
+use OCP\DB\ISchemaWrapper;
+use OCP\DB\Types;
+use OCP\Migration\Attributes\AddColumn;
+use OCP\Migration\Attributes\ColumnType;
+use OCP\Migration\IOutput;
+use OCP\Migration\SimpleMigrationStep;
+
+//#[AddColumn(table: 'user_oidc', name: 'provider_id', type: ColumnType::INTEGER, description: 'Store the id of the provider for this user')]
+//#[AddColumn(table: 'user_oidc', name: 'sub', type: ColumnType::STRING, description: 'Store the sub for this user')]
+class Version081100Date20260824120000 extends SimpleMigrationStep {
+	public function changeSchema(IOutput $output, Closure $schemaClosure, array $options): ?ISchemaWrapper {
+		/** @var ISchemaWrapper $schema */
+		$schema = $schemaClosure();
+		$changed = false;
+
+		$table = $schema->getTable('user_oidc');
+		if (!$table->hasColumn('provider_id')) {
+			$table->addColumn('provider_id', Types::INTEGER, [
+				'notnull' => false,
+				'length' => 4,
+			]);
+			$changed = true;
+		}
+		if (!$table->hasColumn('sub')) {
+			$table->addColumn('sub', Types::STRING, [
+				'notnull' => false,
+				'length' => 256,
+			]);
+			$changed = true;
+		}
+		if (!$table->hasIndex('user_oidc_prov_sub')) {
+			// unique: this is now the primary lookup key for an existing
+			// identity, not just an auxiliary index
+			$table->addUniqueIndex(['provider_id', 'sub'], 'user_oidc_prov_sub');
+			$changed = true;
+		}
+
+		return $changed ? $schema : null;
+	}
+}

--- a/openapi.json
+++ b/openapi.json
@@ -1567,7 +1567,8 @@
                                     },
                                     "userId": {
                                         "type": "string",
-                                        "description": "Provider-specific user identifier"
+                                        "description": "Provider-specific user identifier",
+                                        "minLength": 1
                                     },
                                     "displayName": {
                                         "type": "string",

--- a/tests/unit/Db/UserMapperTest.php
+++ b/tests/unit/Db/UserMapperTest.php
@@ -7,6 +7,7 @@
 
 declare(strict_types=1);
 
+use OCA\UserOIDC\Db\User;
 use OCA\UserOIDC\Db\UserMapper;
 use OCA\UserOIDC\Service\LocalIdService;
 use OCP\AppFramework\Db\DoesNotExistException;
@@ -39,7 +40,7 @@ class UserMapperTest extends TestCase {
 		$this->db = $this->createMock(IDBConnection::class);
 		$this->userMapper = $this->getMockBuilder(UserMapper::class)
 			->setConstructorArgs([$this->db, $this->idService, $this->config])
-			->onlyMethods(['getUser', 'insert'])
+			->onlyMethods(['getUser', 'getByProviderAndSub', 'insert', 'update'])
 			->getMock();
 	}
 
@@ -67,6 +68,10 @@ class UserMapperTest extends TestCase {
 
 	#[DataProvider('dataCreate')]
 	public function testCreate(int $providerId, string $sub, string $generatedId, bool $id4me, string $expected): void {
+		$this->userMapper->expects(self::once())
+			->method('getByProviderAndSub')
+			->willThrowException(new DoesNotExistException('No user'));
+
 		$this->idService->expects(self::once())->method('getId')->with($providerId, $sub, $id4me)->willReturn($generatedId);
 
 		$this->userMapper->expects(self::once())
@@ -78,7 +83,84 @@ class UserMapperTest extends TestCase {
 			->willReturnCallback(function ($arg) {
 				return $arg;
 			});
+		$this->userMapper->expects(self::never())->method('update');
 
-		Assert::assertEquals($expected, $this->userMapper->getOrCreate($providerId, $sub, $id4me)->getUserId());
+		$user = $this->userMapper->getOrCreate($providerId, $sub, $id4me);
+		Assert::assertEquals($expected, $user->getUserId());
+		Assert::assertSame($providerId, $user->getProviderId());
+		Assert::assertSame($sub, $user->getSub());
+	}
+
+	public function testCreateHashesOverlongSub(): void {
+		$longSub = str_repeat('a', 300);
+
+		$this->userMapper->expects(self::once())
+			->method('getByProviderAndSub')
+			->willThrowException(new DoesNotExistException('No user'));
+
+		$this->idService->expects(self::once())->method('getId')->willReturn('short-user-id');
+
+		$this->userMapper->expects(self::once())
+			->method('getUser')
+			->willThrowException(new DoesNotExistException('No user'));
+
+		$this->userMapper->expects(self::once())
+			->method('insert')
+			->willReturnCallback(function ($arg) {
+				return $arg;
+			});
+
+		$user = $this->userMapper->getOrCreate(1, $longSub);
+		Assert::assertSame(hash('sha256', $longSub), $user->getSub());
+	}
+
+	public function testGetOrCreateBackfillsExistingUserWithoutStableIdentifier(): void {
+		// simulates an account provisioned before provider_id/sub existed:
+		// not found by that pair yet, but its computed uid already exists
+		$existing = new User();
+		$existing->setUserId('existing-user');
+		$existing->setDisplayName('Existing User');
+
+		$this->userMapper->expects(self::once())
+			->method('getByProviderAndSub')
+			->willThrowException(new DoesNotExistException('No user'));
+
+		$this->idService->expects(self::once())->method('getId')->willReturn('existing-user');
+
+		$this->userMapper->expects(self::once())
+			->method('getUser')
+			->willReturn($existing);
+
+		$this->userMapper->expects(self::once())
+			->method('update')
+			->willReturnCallback(function ($arg) {
+				return $arg;
+			});
+		$this->userMapper->expects(self::never())->method('insert');
+
+		$user = $this->userMapper->getOrCreate(5, 'the-sub');
+		Assert::assertSame(5, $user->getProviderId());
+		Assert::assertSame('the-sub', $user->getSub());
+	}
+
+	public function testGetOrCreateReturnsExistingUserByProviderAndSubWithoutComputingAUid(): void {
+		$existing = new User();
+		$existing->setUserId('existing-user');
+		$existing->setDisplayName('Existing User');
+		$existing->setProviderId(5);
+		$existing->setSub('the-sub');
+
+		$this->userMapper->expects(self::once())
+			->method('getByProviderAndSub')
+			->with(5, 'the-sub')
+			->willReturn($existing);
+
+		$this->idService->expects(self::never())->method('getId');
+		$this->userMapper->expects(self::never())->method('getUser');
+		$this->userMapper->expects(self::never())->method('update');
+		$this->userMapper->expects(self::never())->method('insert');
+
+		$user = $this->userMapper->getOrCreate(5, 'the-sub');
+		Assert::assertSame($existing, $user);
 	}
 }


### PR DESCRIPTION
Store the provider and OIDC subject claim a user was provisioned from alongside the (possibly hashed) user_id, and look accounts up by this (provider_id, sub) pair first in getOrCreate(). This keeps a provider's own attribute drift (e.g. the mapped uid attribute changing) from forking the account into a second, empty one.

Existing rows are backfilled opportunistically on next login, since the original sub is not recoverable from a one-way hashed user_id.



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
