### PR TITLE
Emit a TokenRefreshedEvent when the login token is refreshed

### DIFF
--- a/lib/Event/TokenRefreshedEvent.php
+++ b/lib/Event/TokenRefreshedEvent.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace OCA\UserOIDC\Event;
+
+use OCA\UserOIDC\Db\Provider;
+use OCP\EventDispatcher\Event;
+
+/**
+ * This event is emitted with the raw token information when the login token is refreshed
+ *
+ * It may be used for further handling of oidc authenticated requests
+ */
+class TokenRefreshedEvent extends Event {
+
+	public function __construct(
+		private array $oldToken,
+		private array $newToken,
+		private Provider $provider,
+		private array $discovery,
+	) {
+		parent::__construct();
+	}
+
+	public function getOldToken(): array {
+		return $this->oldToken;
+	}
+
+	public function getNewToken(): array {
+		return $this->newToken;
+	}
+
+	public function getProvider(): Provider {
+		return $this->provider;
+	}
+
+	public function getDiscovery(): array {
+		return $this->discovery;
+	}
+}

--- a/lib/Service/TokenService.php
+++ b/lib/Service/TokenService.php
@@ -13,6 +13,7 @@ use GuzzleHttp\Exception\ServerException;
 use OC\Authentication\Token\IProvider;
 use OCA\UserOIDC\AppInfo\Application;
 use OCA\UserOIDC\Db\ProviderMapper;
+use OCA\UserOIDC\Event\TokenRefreshedEvent;
 use OCA\UserOIDC\Exception\TokenExchangeFailedException;
 use OCA\UserOIDC\Helper\HttpClientHelper;
 use OCA\UserOIDC\Model\Token;
@@ -276,6 +277,13 @@ class TokenService {
 
 			$bodyArray = json_decode(trim($body), true, 512, JSON_THROW_ON_ERROR);
 			$this->logger->debug('[TokenService] ---- Refresh token success');
+
+			$this->eventDispatcher->dispatchTyped(
+				new TokenRefreshedEvent(
+					$token->jsonSerialize(), $bodyArray, $oidcProvider, $discovery
+				)
+			);
+
 			return $this->storeToken(
 				array_merge($bodyArray, ['provider_id' => $token->getProviderId()])
 			);


### PR DESCRIPTION
Right now, if `store_login_token` is enabled, other apps can request a valid login token when they need it by emitting `ExternalTokenRequestedEvent`.

But in some cases, they might want to only get it once and know when it is refreshed.
So they can listen to the existing `TokenObtainedEvent` to get the login token when the user is logging in and listen to the new `TokenRefreshedEvent` to get the refreshed token only once, when it is obtained.

This could be convenient if an app wants to store the token instead of accessing it everytime they need it.

This should not have any annoying side effect.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
